### PR TITLE
Added test case auto-detection code (in test cases and for test_env lib)

### DIFF
--- a/mbed/test_env.h
+++ b/mbed/test_env.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+ 
 #ifndef TEST_ENV_H_
 #define TEST_ENV_H_
 
@@ -36,6 +37,36 @@ bool notify_completion_str(bool success, char* buffer);
 void notify_performance_coefficient(const char* measurement_name, const int value);
 void notify_performance_coefficient(const char* measurement_name, const unsigned int value);
 void notify_performance_coefficient(const char* measurement_name, const double value);
+
+// Host test auto-detection API
+void notify_host_test_name(const char *host_test);
+void notify_timeout(int timeout);
+void notify_test_id(const char *test_id);
+void notify_test_description(const char *description);
+
+// Host test auto-detection API
+#define MBED_HOSTTEST_START(TESTID)      notify_test_id(TESTID); notify_start()
+#define MBED_HOSTTEST_SELECT(NAME)       notify_host_test_name(#NAME)
+#define MBED_HOSTTEST_TIMEOUT(SECONDS)   notify_timeout(SECONDS)
+#define MBED_HOSTTEST_DESCRIPTION(DESC)  notify_test_description(#DESC)
+#define MBED_HOSTTEST_RESULT(RESULT)     notify_completion(RESULT)
+
+/**
+    Test auto-detection preamble example:
+    main() {
+        MBED_HOSTTEST_TIMEOUT(10);
+        MBED_HOSTTEST_SELECT( host_test );
+        MBED_HOSTTEST_DESCRIPTION(Hello World);
+        MBED_HOSTTEST_START("MBED_10");
+        // Proper 'host_test.py' should take over supervising of this test
+
+        // Test code
+        bool result = ...;
+
+        MBED_HOSTTEST_RESULT(result);
+    }
+*/
+
 
 // Test functionality useful during testing
 unsigned int testenv_randseed();

--- a/source/test_env.cpp
+++ b/source/test_env.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "test_env.h"
 
 // Const strings used in test_end
@@ -69,6 +70,29 @@ bool notify_completion_str(bool success, char* buffer)
         result = true;
     }
     return result;
+}
+
+// Host test auto-detection API
+void notify_host_test_name(const char *host_test) {
+    if (host_test) {
+        printf("{{host_test_name;%s}}" NL, host_test);
+    }
+}
+
+void notify_timeout(int timeout) {
+    printf("{{timeout;%d}}" NL, timeout);
+}
+
+void notify_test_id(const char *test_id) {
+    if (test_id) {
+        printf("{{test_id;%s}}" NL, test_id);
+    }
+}
+
+void notify_test_description(const char *description) {
+    if (description) {
+        printf("{{description;%s}}" NL, description);
+    }
 }
 
 

--- a/test/basic/main.cpp
+++ b/test/basic/main.cpp
@@ -13,7 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "test_env.h"
+
 int main() {
-    notify_completion(true);
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(default_auto);
+    MBED_HOSTTEST_DESCRIPTION(Basic);
+    MBED_HOSTTEST_START("MBED_A1");
+    MBED_HOSTTEST_RESULT(true);
 }

--- a/test/call_before_main/main.cpp
+++ b/test/call_before_main/main.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "test_env.h"
 
 namespace {
@@ -25,6 +26,12 @@ extern "C" void mbed_main() {
 }
 
 int main() {
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(default_auto);
+    MBED_HOSTTEST_DESCRIPTION(Call function mbed_main before main);
+    MBED_HOSTTEST_START("MBED_A21");
+
     printf("MBED: main() starts now!\r\n");
-    notify_completion(mbed_main_called);
+
+    MBED_HOSTTEST_RESULT(mbed_main_called);
 }

--- a/test/cpp/main.cpp
+++ b/test/cpp/main.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "test_env.h"
 
 #define PATTERN_CHECK_VALUE  0xF0F0ADAD
@@ -69,6 +70,11 @@ Heap::hello
 Heap::destroy
 *******************/
 int main (void) {
+    MBED_HOSTTEST_TIMEOUT(10);
+    MBED_HOSTTEST_SELECT(default_auto);
+    MBED_HOSTTEST_DESCRIPTION(C++);
+    MBED_HOSTTEST_START("MBED_12");
+
     bool result = true;
     for (;;)
     {
@@ -92,6 +98,5 @@ int main (void) {
         break;
     }
 
-    notify_completion(result);
-    return 0;
+    MBED_HOSTTEST_RESULT(result);
 }

--- a/test/detect/main.cpp
+++ b/test/detect/main.cpp
@@ -13,13 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "mbed.h"
 #include "test_env.h"
 
 int main() {
+    MBED_HOSTTEST_TIMEOUT(10);
+    MBED_HOSTTEST_SELECT(detect_auto);
+    MBED_HOSTTEST_DESCRIPTION(Simple detect test);
+    MBED_HOSTTEST_START("DTCT_1");
+
     notify_start();
     printf("MBED: Target '%s'\r\n", TEST_SUITE_TARGET_NAME);
     printf("MBED: Test ID '%s'\r\n", TEST_SUITE_TEST_ID);
     printf("MBED: UUID '%s'\r\n", TEST_SUITE_UUID);
-    notify_completion(true);
+    MBED_HOSTTEST_RESULT(true);
 }

--- a/test/dev_null/main.cpp
+++ b/test/dev_null/main.cpp
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "mbed.h"
 #include "test_env.h"
 
-class DevNull : public Stream
-{
+class DevNull : public Stream {
 public:
     DevNull(const char *name = NULL) : Stream(name) {}
 
@@ -32,12 +32,15 @@ protected:
 
 DevNull null("null");
 
-int main()
-{
+int main() {
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(dev_null_auto);
+    MBED_HOSTTEST_DESCRIPTION(stdout redirected to dev null);
+    MBED_HOSTTEST_START("EXAMPLE_1");
+    
     printf("MBED: re-routing stdout to /null\r\n");
     freopen("/null", "w", stdout);
     printf("MBED: printf redirected to /null\r\n");   // This shouldn't appear
     // If failure message can be seen test should fail :)
-    notify_completion(false);   // This is 'false' on purpose
-    return 0;
+    MBED_HOSTTEST_RESULT(false);   // This is 'false' on purpose
 }

--- a/test/div/main.cpp
+++ b/test/div/main.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <utility>      // std::pair
 #include "mbed.h"
 #include "test_env.h"
@@ -32,6 +33,11 @@ const char *result_str(bool result) {
 }
 
 int main() {
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(default_auto);
+    MBED_HOSTTEST_DESCRIPTION(Integer constant division);
+    MBED_HOSTTEST_START("MBED_26");
+
     bool result = true;
 
     {   // 0xFFFFFFFF *  8 =  0x7fffffff8
@@ -50,6 +56,5 @@ int main() {
         printf("64bit: 0x17FFFFFFE8: expected 0x%lX got 0x%lX ... %s\r\n", values.first, test_ret, result_str(test_res));
     }
 
-    notify_completion(result);
-    return 0;
+    MBED_HOSTTEST_RESULT(result);
 }

--- a/test/echo/main.cpp
+++ b/test/echo/main.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "mbed.h"
 #include "test_env.h"
 
@@ -22,17 +23,17 @@
 
 namespace {
     const int BUFFER_SIZE = 48;
+    char buffer[BUFFER_SIZE] = {0};
 }
 
 int main() {
-    char buffer[BUFFER_SIZE] = {0};
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(echo);
+    MBED_HOSTTEST_DESCRIPTION(Serial Echo at 115200);
+    MBED_HOSTTEST_START("MBED_A9");
 
     Serial pc(TXPIN, RXPIN);
     pc.baud(115200);
-
-    pc.puts("{{");
-    pc.puts(TEST_ENV_START);    // Host test is expecting preamble
-    pc.puts("}}");
 
     while (1) {
         pc.gets(buffer, BUFFER_SIZE - 1);

--- a/test/hello/main.cpp
+++ b/test/hello/main.cpp
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "test_env.h"
 
 int main()
 {
-    notify_start();
+    MBED_HOSTTEST_TIMEOUT(5);
+    MBED_HOSTTEST_SELECT(hello_auto);
+    MBED_HOSTTEST_DESCRIPTION(Hello World);
+    MBED_HOSTTEST_START("MBED_10");
+
     printf("Hello World\r\n");
+
     while(1);
 }

--- a/test/rtc/main.cpp
+++ b/test/rtc/main.cpp
@@ -13,11 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "mbed.h"
+#include "test_env.h"
 
 #define CUSTOM_TIME  1256729737
 
 int main() {
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(rtc_auto);
+    MBED_HOSTTEST_DESCRIPTION(RTC);
+    MBED_HOSTTEST_START("MBED_16");
+
     char buffer[32] = {0};
     set_time(CUSTOM_TIME);  // Set RTC time to Wed, 28 Oct 2009 11:35:37
     while(1) {

--- a/test/stdio/main.cpp
+++ b/test/stdio/main.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "mbed.h"
 #include "test_env.h"
 
@@ -22,19 +23,23 @@
  */
 
 int main() {
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(stdio_auto);
+    MBED_HOSTTEST_DESCRIPTION(stdio);
+    MBED_HOSTTEST_START("MBED_2");
+
     DigitalOut led1(LED1);
     DigitalOut led2(LED2);
-    
+
     union {
         int value_int;
     };
 
-    notify_start();
+    notify_start(); // Just to sync with host test supervisor
 
     const char* PRINT_PATTERN = "MBED: Your value was: %d\r\n";
-    
-    while (true)
-    {
+
+    while (true) {
         // SCANF PRINTF family
         value_int = 0;
         led1 = 1;

--- a/test/ticker/main.cpp
+++ b/test/ticker/main.cpp
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "mbed.h"
+#include "test_env.h"
 
 void print_char(char c = '*')
 {
@@ -47,6 +49,11 @@ void flip_2() {
 }
 
 int main() {
+    MBED_HOSTTEST_TIMEOUT(15);
+    MBED_HOSTTEST_SELECT(wait_us_auto);
+    MBED_HOSTTEST_DESCRIPTION(Ticker Int);
+    MBED_HOSTTEST_START("MBED_11");
+
     led1 = 0;
     led2 = 0;
     flipper_1.attach(&flip_1, 1.0); // the address of the function to be attached (flip) and the interval (1 second)

--- a/test/ticker_2/main.cpp
+++ b/test/ticker_2/main.cpp
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "mbed.h"
+#include "test_env.h"
 
 Ticker tick;
 DigitalOut led(LED1);
@@ -41,6 +43,12 @@ void togglePin(void)
 
 int main()
 {
+    MBED_HOSTTEST_TIMEOUT(15);
+    MBED_HOSTTEST_SELECT(wait_us_auto);
+    MBED_HOSTTEST_DESCRIPTION(Ticker Int us);
+    MBED_HOSTTEST_START("MBED_23");
+
     tick.attach_us(togglePin, 1000);
+
     while (1);
 }

--- a/test/ticker_3/main.cpp
+++ b/test/ticker_3/main.cpp
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "mbed.h"
+#include "test_env.h"
 
 void ticker_callback_1(void);
 void ticker_callback_2(void);
@@ -46,6 +48,12 @@ void ticker_callback_1(void)
 
 int main(void)
 {
+    MBED_HOSTTEST_TIMEOUT(15);
+    MBED_HOSTTEST_SELECT(wait_us_auto);
+    MBED_HOSTTEST_DESCRIPTION(Ticker Two callbacks);
+    MBED_HOSTTEST_START("MBED_34");
+
     ticker.attach(ticker_callback_1, 1.0);
+
     while(1);
 }

--- a/test/time_us/main.cpp
+++ b/test/time_us/main.cpp
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "mbed.h"
+#include "test_env.h"
 
 DigitalOut led(LED1);
 
@@ -29,6 +31,11 @@ void print_char(char c = '*')
 
 int main()
 {
+    MBED_HOSTTEST_TIMEOUT(15);
+    MBED_HOSTTEST_SELECT(wait_us_auto);
+    MBED_HOSTTEST_DESCRIPTION(Time us);
+    MBED_HOSTTEST_START("MBED_25");
+
     while (true) {
         for (int i = 0; i < MS_INTERVALS; i++) {
             wait_us(1000);

--- a/test/timeout/main.cpp
+++ b/test/timeout/main.cpp
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "mbed.h"
+#include "test_env.h"
 
 Timeout timer;
 DigitalOut led(LED1);
@@ -22,16 +24,14 @@ namespace {
     const int MS_INTERVALS = 1000;
 }
 
-void print_char(char c = '*')
-{
+void print_char(char c = '*') {
     printf("%c", c);
     fflush(stdout);
 }
 
 void toggleOff(void);
 
-void toggleOn(void)
-{
+void toggleOn(void) {
     static int toggle_counter = 0;
     if (toggle_counter == MS_INTERVALS) {
         led = !led;
@@ -42,13 +42,17 @@ void toggleOn(void)
     timer.attach_us(toggleOff, 500);
 }
 
-void toggleOff(void)
-{
+void toggleOff(void) {
     timer.attach_us(toggleOn, 500);
 }
 
-int main()
-{
+int main() {
+    MBED_HOSTTEST_TIMEOUT(15);
+    MBED_HOSTTEST_SELECT(wait_us_auto);
+    MBED_HOSTTEST_DESCRIPTION(Timeout Int us);
+    MBED_HOSTTEST_START("MBED_24");
+
     toggleOn();
+
     while (1);
 }

--- a/test/vtor_reloc/main.cpp
+++ b/test/vtor_reloc/main.cpp
@@ -62,14 +62,17 @@ static bool test_once() {
 }
 
 int main() {
+    MBED_HOSTTEST_TIMEOUT(15);
+    MBED_HOSTTEST_SELECT(default_auto);
+    MBED_HOSTTEST_DESCRIPTION(Interrupt vector relocation);
+    MBED_HOSTTEST_START("MBED_A18");
 
     // First test, no table reallocation
     {
         printf("Starting first test (interrupts not relocated).\r\n");
         bool ret = test_once();
         if (ret == false) {
-            notify_completion(false);
-            return 1;
+            MBED_HOSTTEST_RESULT(false);
         }
     }
 
@@ -81,11 +84,9 @@ int main() {
 
         bool ret = test_once();
         if (ret == false) {
-            notify_completion(false);
-            return 1;
+            MBED_HOSTTEST_RESULT(false);
         }
     }
 
-    notify_completion(true);
-    return 0;
+    MBED_HOSTTEST_RESULT(true);
 }


### PR DESCRIPTION
# Description

Test suite (`mbed-greentea`) was changed together with test_env files to match requirement for auto-detection of test case and host test supervision.
1. Aligned test cases in `mbed-sdk` with `mbed-greentea` and `mbed-host-tests` workflow.
   See: 
   - https://github.com/ARMmbed/mbed-greentea/README.md
   - https://github.com/ARMmbed/mbed-host-tests/README.md
2. Added missing Apache License, Version 2.0 to modified test case files.
# TODO

We can update all tests ported to new auto-detection scheme for later releases.
# Testing

Added file modification used mbedgt to build new tests and run mbed-greentea (`mbedgt`) with K64F (compiled with GCC):

```
mbedgt --target=frdm-k64f-gcc
mbed-ls: detecting connected mbed-enabled devices...
mbed-ls: detected K64F, console at: COM61, mounted at: E:
        got yotta target 'frdm-k64f-gcc'
mbed-ls: calling yotta to build your sources and tests
warning: uvisor-lib has invalid module.json:
warning:   author value [u'Milosch Meriac <milosch.meriac@arm.com>', u'Alessandro Angelino <alessandro.angelino@arm.com>'] is not valid under any of the given schemas
info: generate for target: frdm-k64f-gcc 0.0.10 at c:\Work\mbed-sdk-private\yotta_targets\frdm-k64f-gcc
mbedOS.cmake included
GCC-C.cmake included
mbedOS-GNU-C.cmake included
GCC-GXX.cmake included
mbedOS-GNU-CXX.cmake included
GCC version is: 4.8.4
GNU-ASM.cmake included
GNU-ASM.cmake included
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Work/mbed-sdk-private/build/frdm-k64f-gcc
ninja: no work to do.
mbedgt: running tests...
        test 'mbed-test-dev_null' .................................................... OK
        test 'mbed-test-stl' ......................................................... SKIPPED
        test 'mbed-test-time_us' ..................................................... OK
        test 'mbed-test-ticker' ...................................................... OK
        test 'mbed-test-div' ......................................................... OK
        test 'mbed-test-detect' ...................................................... SKIPPED
        test 'mbed-test-serial_interrupt' ............................................ SKIPPED
        test 'mbed-test-timeout' ..................................................... OK
        test 'mbed-test-cpp' ......................................................... OK
        test 'mbed-test-sleep_timeout' ............................................... SKIPPED
        test 'mbed-test-call_before_main' ............................................ OK
        test 'mbed-test-blinky' ...................................................... SKIPPED
        test 'mbed-test-stdio' ....................................................... OK
        test 'mbed-test-heap_and_stack' .............................................. SKIPPED
        test 'mbed-test-ticker_3' .................................................... OK
        test 'mbed-test-ticker_2' .................................................... OK
        test 'mbed-test-basic' ....................................................... OK
        test 'mbed-test-cstring' ..................................................... SKIPPED
        test 'mbed-test-rtc' ......................................................... OK
        test 'mbed-test-echo' ........................................................ OK
        test 'mbed-test-hello' ....................................................... OK
        got yotta target 'frdm-k64f-armcc'
```
