### PR TITLE
Eliminate warnings from mbed-sdk

### DIFF
--- a/mbed/DirHandle.h
+++ b/mbed/DirHandle.h
@@ -82,7 +82,7 @@ public:
      *
      *  @param location The location to seek to. Must be a value returned by telldir.
      */
-    virtual void seekdir(off_t location) { }
+    virtual void seekdir(off_t location) { (void) location;}
 
     virtual ~DirHandle() {}
 };

--- a/mbed/FileSystemLike.h
+++ b/mbed/FileSystemLike.h
@@ -61,7 +61,7 @@ public:
      *  @param filename the name of the file to remove.
      *  @param returns 0 on success, -1 on failure.
      */
-    virtual int remove(const char *filename) { return -1; };
+    virtual int remove(const char *filename) { (void) filename; return -1; };
 
     /** Rename a file in the filesystem.
      *
@@ -72,7 +72,7 @@ public:
      *    0 on success,
      *   -1 on failure.
      */
-    virtual int rename(const char *oldname, const char *newname) { return -1; };
+    virtual int rename(const char *oldname, const char *newname) { (void) oldname, (void) newname; return -1; };
 
     /** Opens a directory in the filesystem and returns a DirHandle
      *   representing the directory stream.
@@ -83,7 +83,7 @@ public:
      *    A DirHandle representing the directory stream, or
      *   NULL on failure.
      */
-    virtual DirHandle *opendir(const char *name) { return NULL; };
+    virtual DirHandle *opendir(const char *name) { (void) name; return NULL; };
 
     /** Creates a directory in the filesystem.
      *
@@ -94,7 +94,7 @@ public:
      *    0 on success,
      *   -1 on failure.
      */
-    virtual int mkdir(const char *name, mode_t mode) { return -1; }
+    virtual int mkdir(const char *name, mode_t mode) { (void) name, (void) mode; return -1; }
 
     // TODO other filesystem functions (mkdir, rm, rn, ls etc)
 };

--- a/source/SPI.cpp
+++ b/source/SPI.cpp
@@ -29,6 +29,7 @@ SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName _unused) :
         _bits(8),
         _mode(0),
         _hz(1000000) {
+    (void) _unused;
     spi_init(&_spi, mosi, miso, sclk, NC);
     spi_format(&_spi, _bits, _mode, 0);
     spi_frequency(&_spi, _hz);

--- a/source/Stream.cpp
+++ b/source/Stream.cpp
@@ -75,6 +75,7 @@ ssize_t Stream::read(void* buffer, size_t length) {
 }
 
 off_t Stream::lseek(off_t offset, int whence) {
+    (void) offset, (void) whence;
     return 0;
 }
 

--- a/source/retarget.cpp
+++ b/source/retarget.cpp
@@ -196,6 +196,7 @@ extern "C" size_t    __write (int        fh, const unsigned char *buffer, size_t
 #else
 extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsigned int length, int mode) {
 #endif
+    (void) mode;
     int n; // n is the number of bytes written
     if (fh < 3) {
 #if DEVICE_SERIAL
@@ -223,6 +224,7 @@ extern "C" size_t    __read (int        fh, unsigned char *buffer, size_t       
 #else
 extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int length, int mode) {
 #endif
+    (void) mode;
     int n; // n is the number of bytes read
     if (fh < 3) {
         // only read a character at a time from stdin
@@ -335,6 +337,7 @@ extern "C" int rename(const char *oldname, const char *newname) {
 }
 
 extern "C" char *tmpnam(char *s) {
+    (void) s;
     return NULL;
 }
 

--- a/test/cpp/main.cpp
+++ b/test/cpp/main.cpp
@@ -21,7 +21,7 @@ class Test {
 
 private:
     const char* name;
-    const int pattern;
+    const unsigned pattern;
 
 public:
     Test(const char* _name) : name(_name), pattern(PATTERN_CHECK_VALUE)  {

--- a/test/stl/main.cpp
+++ b/test/stl/main.cpp
@@ -61,7 +61,7 @@ struct printFloat {
 };
 
 struct printString {
-    void operator()(char* s) {
+    void operator()(const char* s) {
         printf("%s ", s);
     }
 };
@@ -88,7 +88,7 @@ int main()
     }
 
     {
-        char* floats_str[] = {FLOATS_STR};
+        const char* floats_str[] = {FLOATS_STR};
         float floats_transform[TABLE_SIZE(floats_str)] = {0.0};
         std::transform(floats_str, floats_str + TABLE_SIZE(floats_str), floats_transform, atof);
         bool equal_result = std::equal(floats_transform, floats_transform + TABLE_SIZE(floats_transform), floats);


### PR DESCRIPTION
This change should eliminate all the build warnings from mbed-sdk.
