### PR TITLE
Disable asynch spi test on targets that don’t support it

### DIFF
--- a/test/asynch_spi/asynch_spi.cpp
+++ b/test/asynch_spi/asynch_spi.cpp
@@ -21,10 +21,6 @@
 
 #if DEVICE_SPI_ASYNCH
 
-#if !DEVICE_SPI
-#error spi_master_asynch requires SPI
-#endif
-
 #define SHORT_XFR 3
 #define LONG_XFR 16
 #define TEST_BYTE0 0x00


### PR DESCRIPTION
@0xc0170 @bogdanm @marcuschangarm 

Please take a look.  It's fine if the asynch tests fail on targets that don't support asynch operation, but they should, at least, compile, even if that's through preprocessor magic.
