### PR TITLE
Fix dependency on MINAR

### DIFF
--- a/module.json
+++ b/module.json
@@ -25,7 +25,7 @@
     "mbed-hal": "~0.3.0",
     "cmsis-core": "~0.2.0",
     "mbed-alloc": "~0.0.0",
-    "minar": "~0.1.3"
+    "minar": "~0.3.0"
   },
   "targetDependencies": {},
   "scripts": {


### PR DESCRIPTION
Currently, the MINAR dependency is generating incompatible version errors.
