### PR TITLE
Added mbed_assert.h to be included in mbed.h

### DIFF
--- a/mbed/mbed.h
+++ b/mbed/mbed.h
@@ -28,6 +28,7 @@
 // mbed Debug libraries
 #include "mbed_error.h"
 #include "mbed_interface.h"
+#include "mbed_assert.h"
 
 // mbed Peripheral components
 #include "DigitalIn.h"


### PR DESCRIPTION
This makes it possible to build minar on platforms that do not have the mbed_assert.h included in its drivers.
