### PR TITLE
Rework the sbrk-mini test to work with appstart.

### DIFF
--- a/test/sbrk-mini/main.cpp
+++ b/test/sbrk-mini/main.cpp
@@ -7,6 +7,84 @@ extern void * volatile mbed_sbrk_ptr;
 extern volatile uintptr_t mbed_sbrk_diff;
 
 #define TEST_SMALL sizeof(uint32_t)
+#define CHECK_EQ(A,B,P,F,L)\
+    ((A) == (B) ? 1 : ((P) = false, (F) = __FILE__, (L) = __LINE__, 0))
+#define CHECK_NEQ(A,B,P,F,L)\
+    ((A) != (B) ? 1 : ((P) = false, (F) = __FILE__, (L) = __LINE__, 0))
+
+
+bool runTest(int * line, const char ** file) {
+    bool tests_pass = true;
+
+    do {
+        uintptr_t init_sbrk_ptr = (uintptr_t)mbed_sbrk(0);
+        uintptr_t ptr;
+        ptr = (uintptr_t) mbed_sbrk(TEST_SMALL);
+        if(!CHECK_EQ(ptr, (uintptr_t) init_sbrk_ptr, tests_pass, *file, *line)) {
+            break;
+        }
+
+        ptr = (uintptr_t) mbed_sbrk(TEST_SMALL);
+        if(!CHECK_EQ(ptr, init_sbrk_ptr + TEST_SMALL, tests_pass, *file, *line)) {
+            break;
+        }
+
+        ptr = (uintptr_t) mbed_krbs(TEST_SMALL);
+        if(!CHECK_EQ(ptr, (uintptr_t) &__mbed_krbs_start - TEST_SMALL, tests_pass, *file, *line)) {
+            break;
+        }
+        if(!CHECK_EQ(mbed_sbrk_diff, (ptrdiff_t)&__heap_size - 3*TEST_SMALL - (init_sbrk_ptr - (uintptr_t)&__mbed_sbrk_start), tests_pass, *file, *line)) {
+            break;
+        }
+
+
+        // Test small increments
+        for (unsigned int i = 0; tests_pass && i < TEST_SMALL; i++) {
+            ptr = (uintptr_t) mbed_krbs(i);
+            if(!CHECK_EQ(0, ptr & (TEST_SMALL - 1), tests_pass, *file, *line)) {
+                break;
+            }
+        }
+        for (unsigned int i = 0; tests_pass && i < TEST_SMALL; i++) {
+            ptr = (uintptr_t) mbed_sbrk(i);
+            if(!CHECK_EQ(0, (uintptr_t) mbed_sbrk_ptr & (TEST_SMALL - 1), tests_pass, *file, *line)) {
+                break;
+            }
+        }
+
+        // Allocate a big block
+        ptr = (uintptr_t) mbed_sbrk((ptrdiff_t)&__heap_size);
+        if(!CHECK_EQ((intptr_t)ptr, -1, tests_pass, *file, *line)) {
+            break;
+        }
+
+        ptr = (uintptr_t) mbed_krbs((ptrdiff_t)&__heap_size);
+        if(!CHECK_EQ((intptr_t)ptr, -1, tests_pass, *file, *line)) {
+            break;
+        }
+
+        break;
+
+    } while (0);
+    return tests_pass;
+}
+
+class Test {
+public:
+    Test():_pass(false), _line(0), _file(NULL)
+    {
+        _pass = runTest(&_line, &_file);
+    }
+    bool passed() {return _pass;}
+    int line() {return _line;}
+    const char * file() {return _file;}
+private:
+    bool _pass;
+    int _line;
+    const char *_file;
+};
+
+Test early_test;
 
 void app_start(int, char*[])
 {
@@ -14,63 +92,11 @@ void app_start(int, char*[])
     MBED_HOSTTEST_SELECT(default);
     MBED_HOSTTEST_DESCRIPTION(sbrk mini test);
     MBED_HOSTTEST_START("SBRK_MINI_TEST");
-    bool tests_pass = false;
 
-    do {
-        uintptr_t init_sbrk_ptr = (uintptr_t)mbed_sbrk(0);
-        uintptr_t ptr;
-        ptr = (uintptr_t) mbed_sbrk(TEST_SMALL);
-        if (ptr != (uintptr_t) init_sbrk_ptr) {
-            break;
-        }
-        ptr = (uintptr_t) mbed_sbrk(TEST_SMALL);
-        if (ptr != init_sbrk_ptr + TEST_SMALL) {
-            break;
-        }
-        ptr = (uintptr_t) mbed_krbs(TEST_SMALL);
-        if (ptr != (uintptr_t) &__mbed_krbs_start - TEST_SMALL) {
-            break;
-        }
-        if (mbed_sbrk_diff != (ptrdiff_t)&__heap_size - 3*TEST_SMALL - (init_sbrk_ptr - (uintptr_t)&__mbed_sbrk_start)) {
-            break;
-        }
+    if (!early_test.passed()) {
+        printf("MBED: Failed at %s:%d\r\n", early_test.file(), early_test.line());
+    }
 
-        tests_pass = true;
-        // Test small increments
-        for (unsigned int i = 0; tests_pass && i < TEST_SMALL; i++) {
-            ptr = (uintptr_t) mbed_krbs(i);
-            if (ptr & (TEST_SMALL - 1)) {
-                tests_pass = false;
-            }
-        }
-        if (!tests_pass) {
-            break;
-        }
-        for (unsigned int i = 0; tests_pass && i < TEST_SMALL; i++) {
-            ptr = (uintptr_t) mbed_sbrk(i);
-            if ((uintptr_t) mbed_sbrk_ptr & (TEST_SMALL - 1)) {
-                tests_pass = false;
-            }
-        }
-        if (!tests_pass) {
-            break;
-        }
-        tests_pass = false;
-
-        // Allocate a big block
-        ptr = (uintptr_t) mbed_sbrk((ptrdiff_t)&__heap_size);
-        if (ptr != (uintptr_t) -1) {
-            break;
-        }
-        ptr = (uintptr_t) mbed_krbs((ptrdiff_t)&__heap_size);
-        if (ptr != (uintptr_t) -1) {
-            break;
-        }
-
-        tests_pass = true;
-
-    } while (0);
-
-    MBED_HOSTTEST_RESULT(tests_pass);
+    MBED_HOSTTEST_RESULT(early_test.passed());
     return;
 }


### PR DESCRIPTION
This PR uses a static object initializer to run before main has happened so that sbrk results are uncorrupted.
