### PR TITLE
destructor for classes involved in a hierarchy should be marked virtual

### DIFF
--- a/mbed/FunctionPointerBind.h
+++ b/mbed/FunctionPointerBind.h
@@ -53,7 +53,7 @@ public:
         *this = fp;
     }
 
-    ~FunctionPointerBind() {
+    virtual ~FunctionPointerBind() {
         _ops->destructor(_storage);
     }
 


### PR DESCRIPTION
This gets rid of a compiler warning when building with armcc.

CR @bogdanm 
