### PR TITLE
Updates to the SPI driver model

### DIFF
--- a/mbed/SPI.h
+++ b/mbed/SPI.h
@@ -30,84 +30,6 @@
 #include "Transaction.h"
 #endif
 
-
-/**
- * SPI Transaction Details
- *      ___                 _                ____
- * SSEL    |_______________|_|______________|
- * SCK  __________XXXXXXXX______XXXXXXXX_________
- *         |     |       | | | |       |    |
- *         |     |       | | | |       |    |
- *         |     |       | | | |       |    + afterXfer()
- *         |     |       | | | |       + SPIirq()
- *         |     |       | | | + sendData()
- *         |     |       | | + beforeXfer()
- *         |     |       | + afterXfer()
- *         |     |       + SPIirq()
- *         |     + sendData()
- *         + beforeXfer()
- *
- * beforeXfer() :
- *     If a transfer is not active:
- *         Dequeue a transaction
- *         If there is a user pre-xfer callback:
- *             call the user pre-xfer callback
- *         Configure the SPI peripheral with the transaction's configuration parameters
- *         If the transaction requires autotoggle and the peripheral does not support it:
- *             Disable FIFOs
- *             Enable interrupt on every word
- *     If CS is not managed:
- *         If CS is not NC:
- *             set GPIO active (CS)
- *         If the setup delay is not 0:
- *             post sendData() to execute (setup delay) from now
- *     If sendData() was not posted:
- *         call sendData()
- *     Done
- *
- * sendData():
- *     If DMA is enabled:
- *         Start the DMA transfer
- *     Otherwise:
- *         If FIFOs are enabled:
- *             Fill the send FIFO
- *         Otherwise:
- *             call SendWord()
- *     Done
- *
- *
- * SPIirq():
- *     clear callSetCSInactive
- *     if FIFOs are enabled:
- *         empty the recv FIFO
- *         refill the send FIFO
- *     Otherwise:
- *         If CS is not managed:
- *             If the hold delay is not 0:
- *                 post callAfterXfer() to execute (hold delay) from now
- *         If callAfterXfer() was not posted:
- *             set callAfterXfer
- *     If there are no more words to send or receive:
- *         If there is a user post-xfer irqCallback:
- *             Call the user post-xfer irqCallback
- *         set callAfterXfer
- *     If callAfterXfer:
- *         call afterXfer()
- *     Done
- *
- * afterXfer():
- *     If CS is not managed:
- *         If CS is not NC:
- *             set GPIO inactive (CS)
- *         If inactive delay is not 0:
- *             post beforeXfer() to execute (inactive delay) from now
- *     If beforeXfer was not posted:
- *         call beforeXfer()
- *     Done
- */
-
-
-
 namespace mbed {
 
 /** A SPI Master, used for communicating with SPI slave devices
@@ -199,38 +121,6 @@ public:
      * @return Zero if the transfer has started, or -1 if SPI peripheral is busy
      */
     int transfer(void *tx_buffer, int tx_length, void *rx_buffer, int rx_length, const event_callback_t& callback, int event = SPI_EVENT_COMPLETE);
-    class TransferParameters {
-        friend SPI;
-    public:
-        TransferParameters();
-        TransferParameters & frequency(uint32_t freq);
-        TransferParameters & irq_callback(const event_callback_t &irqCallback);
-        TransferParameters & callback(const event_callback_t &callback);
-        TransferParameters & tx_buffer(const void * buf, size_t length);
-        TransferParameters & rx_buffer(void * buf, size_t length);
-        TransferParameters & event_mask(int mask);
-        TransferParameters & cs_pin(PinName cs);
-        TransferParameters & cs_setup_time(uint32_t microseconds);
-        TransferParameters & cs_hold_time(uint32_t microseconds);
-
-        ~TransferParameters();
-    private:
-        uint32_t _freq;
-        event_callback_t _irqCallback;
-        event_callback_t _callback;
-        void * _tx;
-        void * _rx;
-        size_t _tlen;
-        size_t _rlen;
-        int _eventMask;
-        PinName _cs;
-        uint32_t _cs_setup_time;
-        uint32_t _cs_hold_time;
-        uint8_t _spi_mode;
-    }
-    int post_transfer(const TransferParameters & tp) {
-        return transfer(tp._tx,tp._tlen,tp._rx,tp._rlen,tp._callback,tp._eventMask);
-    }
 
      /** Start non-blocking SPI transfer.
      *

--- a/source/SPI.cpp
+++ b/source/SPI.cpp
@@ -176,68 +176,6 @@ void SPI::irq_handler_asynch(void)
 #endif
 }
 
-SPI::TransferParameters::TransferParameters():
-    _freq(0),
-    _irqCallback(),
-    _callback(),
-    _tx(NULL),
-    _rx(NULL),
-    _tlen(0),
-    _rlen(0),
-    _eventMask(-1),
-    _cs(),
-    _posted(false),
-    _spi(NULL)
-{
-}
-TransferParameters & SPI::TransferParameters::frequency(uint32_t freq)
-{
-    _freq = freq;
-    return *this;
-}
-TransferParameters & SPI::TransferParameters::irq_callback(event_callback_t irqCallback)
-{
-    _irqCallback = irqCallback;
-    return *this;
-}
-TransferParameters & SPI::TransferParameters::callback(event_callback_t callback)
-{
-    _callback = callback;
-    return *this;
-}
-TransferParameters & SPI::TransferParameters::tx_buffer(void * buf, size_t length)
-{
-    _tx = buf;
-    _tlen = length;
-    return *this;
-}
-TransferParameters & SPI::TransferParameters::rx_buffer(void * buf, size_t length)
-{
-    _rx = buf;
-    _rlen = length;
-    return *this;
-}
-TransferParameters & SPI::TransferParameters::event_mask(int mask)
-{
-    _eventMask = mask;
-    return *this;
-}
-TransferParameters & SPI::TransferParameters::cs_pin(PinName cs)
-{
-    _cs = cs;
-    return *this;
-}
-
-SPI::TransferParameters::~TransferParameters() {
-    if(_spi && !_posted) {
-        int err = _spi->transfer(_tx,_tlen,_rx,_rlen,_callback,_eventMask);
-        if (err && _callback) {
-            minar::Scheduler::postCallback(_callback.bind(SPI_EVENT_ERROR));
-        }
-    }
-}
-
-
 #endif
 
 } // namespace mbed


### PR DESCRIPTION
This is an extensive PR.  It's not tested or ready for merge, but it _is_ ready for feedback!

Highlights:
- SPI objects now all reference a singleton (one per physical port)
- SPI configuration is done on a per-transaction basis
- SPI chip selects are now supported, including toggle modes, pre-transfer delays, post transfer delays, and minimum idle times.
- Three user callbacks are supported; two in irq context (one before transfer, one after) as well as the regular post-transfer scheduled callback
- Most asynchronous operation has been moved into the C++ API, which should greatly reduce the porting effort for the HAL.
- The scope of the HAL has been greatly reduced
- The model for specifying transfers now follows the named parameter idiom for C++

@bogdanm @0xc0170 
