### PR TITLE
Module and readme - set correct github links. Fixes #80

### DIFF
--- a/module.json
+++ b/module.json
@@ -8,10 +8,10 @@
   ],
   "author": "Bogdan Marinescu <bogdan.marinescu@arm.com>",
   "repository": {
-    "url": "git@github.com:mbedmicro/mbed_private.git",
+    "url": "git@github.com:ARMmbed/mbed-drivers.git",
     "type": "git"
   },
-  "homepage": "https://github.com/mbedmicro/mbed_private",
+  "homepage": "https://github.com/ARMmbed/mbed-drivers",
   "licenses": [
     {
       "url": "https://spdx.org/licenses/Apache-2.0",

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
 ## Building with yotta
 
-The mbed OS's SDK is built using yotta. So first, install [yotta](http://github.com/ARMmbed/yotta), then:
+The mbed OS's drivers are built using yotta. So first, install [yotta](http://github.com/ARMmbed/yotta), then:
 
 ```bash
 # get the mbed-sdk source:
-git clone git@github.com:mbedmicro/mbed-sdk.git
-cd mbed-sdk
+git clone git@github.com:ARMmbed/mbed-drivers.git
+cd mbed-drivers
 
 # build for the frdm-k64f-gcc target:
 yotta target frdm-k64f-gcc


### PR DESCRIPTION
This corrects the links in the module, the readme file.

@bogdanm @bremoran 