### PR TITLE
Adding pinmap function

### DIFF
--- a/mbed/pinmap_common.h
+++ b/mbed/pinmap_common.h
@@ -1,0 +1,42 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef PINMAP_COMMON_H
+#define PINMAP_COMMON_H
+
+#include "PinNames.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    PinName pin;
+    int peripheral;
+    int function;
+} PinMap;
+
+uint32_t pinmap_peripheral(PinName pin, const PinMap* map);
+uint32_t pinmap_function(PinName pin, const PinMap* map);
+uint32_t pinmap_merge(uint32_t a, uint32_t b);
+void     pinmap_pinout(PinName pin, const PinMap *map);
+uint32_t pinmap_find_peripheral(PinName pin, const PinMap* map);
+uint32_t pinmap_find_function(PinName pin, const PinMap* map);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/source/pinmap_common.c
+++ b/source/pinmap_common.c
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2013 ARM Limited
+ * Copyright (c) 2006-2015 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,4 +66,24 @@ uint32_t pinmap_peripheral(PinName pin, const PinMap* map) {
     if ((uint32_t)NC == peripheral) // no mapping available
         error("pinmap not found for peripheral");
     return peripheral;
+}
+
+uint32_t pinmap_find_function(PinName pin, const PinMap* map) {
+    while (map->pin != NC) {
+        if (map->pin == pin)
+            return map->function;
+        map++;
+    }
+    return (uint32_t)NC;
+}
+
+uint32_t pinmap_function(PinName pin, const PinMap* map) {
+    uint32_t function = (uint32_t)NC;
+
+    if (pin == (PinName)NC)
+        return (uint32_t)NC;
+    function = pinmap_find_function(pin, map);
+    if ((uint32_t)NC == function) // no mapping available
+        error("pinmap not found for function");
+    return function;
 }


### PR DESCRIPTION
This should fix reported problem of missing definitions for pinmap_function().

References:
- mbed-hal - https://github.com/ARMmbed/mbed-hal/pull/19

Tested with st target which uses pinmap_function() and k64f. A note, the implementation is from mbed - no changes in those 2 functions.

@bogdanm @bremoran 