### PR TITLE
[breaking change] mbed_sdk_init rename to mbed_hal_init

### DIFF
--- a/source/retarget.cpp
+++ b/source/retarget.cpp
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include "app.h"
 #include "minar/minar.h"
+#include "mbed-hal/init_api.h"
 
 #if defined(__ARMCC_VERSION)
 #   include <rt_sys.h>
@@ -419,26 +420,22 @@ extern "C" __weak void __cxa_pure_virtual(void) {
 #endif
 
 // ****************************************************************************
-// mbed_sdk_init() is a function that is called before starting the scheduler,
+// mbed_hal_init() is a function that is called before starting the scheduler,
 // it is not meant for user code, but for HAL ports to perform initialization
 // before the scheduler is started
-
-extern "C" __weak void mbed_sdk_init(void);
-extern "C" __weak void mbed_sdk_init(void) {
-}
 
 #if defined(TOOLCHAIN_ARM)
 extern "C" int $Super$$main(void);
 
 extern "C" int $Sub$$main(void) {
-    mbed_sdk_init();
+    mbed_hal_init();
     return $Super$$main();
 }
 #elif defined(TOOLCHAIN_GCC)  || defined(TARGET_LIKE_CLANG)
 extern "C" int __real_main(void);
 
 extern "C" int __wrap_main(void) {
-    mbed_sdk_init();
+    mbed_hal_init();
     return __real_main();
 }
 #elif defined(TOOLCHAIN_IAR)
@@ -446,9 +443,9 @@ extern "C" int __wrap_main(void) {
 // to ld's --wrap. It does have a --redirect, but that doesn't help, since redirecting
 // 'main' to another symbol looses the original 'main' symbol. However, its startup
 // code will call a function to setup argc and argv (__iar_argc_argv) if it is defined.
-// Since mbed doesn't use argc/argv, we use this function to call mbed_sdk_init.
+// Since mbed doesn't use argc/argv, we use this function to call mbed_hal_init.
 extern "C" void __iar_argc_argv() {
-    mbed_sdk_init();
+    mbed_hal_init();
 }
 #endif
 


### PR DESCRIPTION
mbed_hal_init (formerly mbed_sdk_init) is a strong declared. This change will require to be mbed_hal_init defined in target's hal. Therefore before merging, I'll need to reference changes in our HAL.

There's still wrapping the main, this can be factored out as we define main. Or at least, mbed_hal_init() invoked in main, this wrapping stays empty.

References:
- mbed-hal - https://github.com/ARMmbed/mbed-hal/pull/20
- hal-frdm-k64f- - https://github.com/ARMmbed/mbed-hal-frdm-k64f/pull/8
- hal-stmf4 - https://github.com/ARMmbed/mbed-hal-st-stm32f4/pull/11

@bogdanm @bremoran @autopulated @rgrover 