### PR TITLE
SPI: Issue error callback on buffer validation failure.

### DIFF
--- a/mbed/SPI.h
+++ b/mbed/SPI.h
@@ -118,7 +118,8 @@ public:
      * @param rx_length The length of RX buffer
      * @param callback  The event callback function
      * @param event     The logical OR of SPI events to modify. Look at spi hal header file for SPI events.
-     * @return Zero if the transfer has started, or -1 if SPI peripheral is busy
+     * @retval 0 if the transfer has started or has been queued
+     * @retval -1 if SPI peripheral is busy or the transfer could not be queued
      */
     int transfer(void *tx_buffer, int tx_length, void *rx_buffer, int rx_length, const event_callback_t& callback, int event = SPI_EVENT_COMPLETE);
 

--- a/source/SPI.cpp
+++ b/source/SPI.cpp
@@ -76,6 +76,9 @@ int SPI::transfer(void *tx_buffer, int tx_length, void *rx_buffer, int rx_length
 }
 
 int SPI::transfer(const Buffer& tx, const Buffer& rx, const event_callback_t& callback, int event) {
+    // the buffers must be valid, i.e. one of the buffers needs to be non-null in both pointer and length
+    MBED_ASSERT((tx.buf != NULL and tx.length != 0) or (rx.buf != NULL and rx.length != 0));
+
     if (spi_active(&_spi)) {
         return queue_transfer(tx, rx, callback, event);
     }


### PR DESCRIPTION
When using invalid buffers, the callback chain is intentionally broken,
since no callback is ever called.

This should never be a silent failure, even on user error.

In fact, `SPI_EVENT_ERROR` should be non-maskable and there should always be an error check in the callback.
If the user really does not want a callback, it can still be set to `NULL`.

@0xc0170 @bremoran 