### PR TITLE
Add a prototype fluent API for I2C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,4 @@ build
 .yotta.json
 
 # doxygen output
-docs
+doxygen-output

--- a/Doxyfile
+++ b/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ./docs
+OUTPUT_DIRECTORY       = ./doxygen-output
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/docs/I2C.md
+++ b/docs/I2C.md
@@ -1,0 +1,124 @@
+**Warning: this API is experimental and may be subject to change**
+
+# Asynchronous I2C
+I2C is a 2-wire serial bus protocol, designed to provide easy communication between peripherals on the same circuit board.
+
+The I2C class provides an asynchronous usage model for I2C master mode.
+
+In order to facilitate sharing an I2C master mode controller between drivers for connected peripherals, an I2C resource manager is required. This resource manager provides a single interface: `post_transaction()`, an API which adds a transaction to the transaction queue. The `I2C` class interfaces with an I2C Resource manager in order to initiate transactions and receive events. The `I2CTransaction` class encapsulates all I2C transaction parameters. The `I2CResourceManager` class is a generic interface for implementing I2C resource managers.
+
+Different resource managers are required for each kind of I2C master. By default, only the resource manager matching the on-chip I2C master is provided.
+
+Transaction queues are composed of one or more transmit or receive segments, each of which contains a buffer, a direction and, optionally, an callback to execute in IRQ context between finishing the current segment and starting the next.
+
+Typically, transactions should only be created in non-IRQ context, since they require allocating memory. However, if two pool allocators (one for the `I2CTransaction` and one for the `I2CSegments`) is provided to the `I2C` object on construction, it can use `transfer_to_irqsafe` to build a transaction in IRQ context.
+
+# I2C
+I2C encapsulates an I2C master. The physical I2C master to use is selected via the pins provided to the constructor. The `frequency()` API sets the default frequency for transactions issued from the I2C object. This is used for each transaction issued by I2C unless overridden when creating the transaction. Transactions are initiated by calling `transfer_to()` or ```transfer_to_irqsafe()```. Both of these APIs create an instance of the `TransferAdder` helper class.
+
+# TransferAdder
+The TransferAdder class allows convenient construction of complex transfers.
+
+The `frequency()` member overrides the default frequency set by the issuing I2C object.
+
+The `on()` member allows setting up to 4 event handlers, each with a corresponding event mask.
+
+The `tx()` members add a buffer to send to the transfer.
+
+The `rx()` members add a buffer to receive into to the transfer. There is a special case of `rx()`, which doesn't use a normal buffer. When `rx(size_t)` is called with a size of less than 8 bytes, the underlying EphermeralBuffer is placed in ephemeral mode. This means that no preallocated receive buffer is needed, instead the data is packed directly into the EphemeralBuffer. This has a side-effect that the data will be freed once the last event handler has exited, so if the data must be retained, it should be copied out.
+
+The `apply()` method validates the transfer and adds it to the transaction queue of the I2CResourceManager. It returns the result of validation.
+
+# I2C Resource Managers
+I2C Resource managers are instantiated statically and initialized on first use. There is one Resource Manager per logical I2C master. Logical I2C masters could consist of:
+
+* Onchip I2C masters
+* I2C Bridges (SPI->I2C bridge, I2C->I2C bridge, etc.)
+* Bit banged I2C
+* Bit banged I2C over SPI GPIO expander
+* More...
+
+Currently only onchip I2C masters are supported.
+
+The I2CResourceManager manager is a multiplexer that guarantees mutually exclusive access to the underlying hardware I2C master. It does this by serializing transactions and ensuring that they are processed atomically. This way, there can be many users of the I2C bus, without access conflicts.
+
+The I2CResourceManager is the interface required to manage a particular I2C master. It provides several common operations, but explicitly does not permit copy or move construction or assignment.
+
+The common operations provided by the Resource manager are:
+
+* Adding a transaction to the queue
+* Processing an event
+
+These operations are common to all resource managers, so they are provided by the interface class.
+
+## Event Handling overview
+
+When an interrupt occurs, the HAL processes it; if anything needs to be handled by the upper layers, an event is generated. The derived resource manager should call I2CResourceManager::process_event with this event. If appropriate, the I2CResourceManager will call the I2CSegment's irq callback handler.
+
+The resource manager handles events according to the following pseudocode:
+
+```
+If there is an error condition:
+     Schedule handle_event() with the current transaction and event
+Otherwise, if there are more segments to process:
+     Start the next segment
+Otherwise,
+     Schedule handle_event() with the current transaction and the done flag
+If another segment was not started,
+     Start the next transaction
+```
+
+`handle_event()` calls the registered event handlers for the current transaction, then frees the Transaction, using the I2C object that originally issued the transaction.
+
+# I2C transactions
+An I2CTransaction contains a list of event handlers and their event masks, an I2C address, an operating frequency, and zero or more I2CSegments. Zero-segment Transactions are explicitly supported since they are useful in connected device discovery (pings).
+
+# I2C Segments
+An I2CSegment is a wrapper around an EphemeralBuffer. It provides an I2C transfer direction (read or write) and an optional callback to execute in IRQ context. I2CSegments also provide a chaining pointer so that they can perform sequential or scatter/gather operations.
+
+# Example: constructing I2C transactions
+
+```C++
+void doneCB(bool dir, I2CTransaction *t, uint32_t event) {
+    // Do something
+}
+I2C i2c0(sda, scl);
+void app_start (int, char **) {
+    uint8_t cmd[2] = {0xaa, 0x55};
+    i2c0.transfer_to(addr).tx(cmd,2).rx(4).on(I2C_EVENT_ALL, doneCB);
+}
+```
+
+# Example: Handling I2C events
+
+```C++
+ // Read 6 bytes from I2C EEPROM slave at address 0x62
+
+ #include "mbed.h"
+
+mbed::drivers::v2::I2C i2c(p28, p27);
+
+// This callback executes in minar context
+void xfer_done(mbed::drivers::v2::I2CTransaction * t, int event) {
+    t->reset_current(); // Set the current pointer to root.
+    uint8_t *txPtr = t->get_current->get_buf();
+    printf("EEPROM 0x%02x@0x%02x%02x: ", t->address(), txPtr[0], txPtr[1]);
+    // Get the rx buffer pointer
+    uint8_t * rxPtr = t->get_current() // get the first segment (the tx segment)
+                       ->get_next()    // get the second segment (the rx segment)
+                       ->get_buf();    // get the buffer pointer
+    for (uint i = 0; i < 6; i++) {
+        printf("%02x", rxPtr[i]);
+    }
+    printf("\n");
+    // Both the tx and rx buffers are ephemeral, so they will be freed automatically when this function exits
+}
+
+void app_start(int, char **) {
+    i2c.transfer_to(0x62)           // I2C Slave Address
+       .tx_ephemeral("\x12\x34", 2) // Send EEPROM location
+       .rx(6)                       // Read 6 bytes into an ephemeral buffer
+       .on(I2C_EVENT_TRANSFER_COMPLETE, xfer_done)
+       .apply();
+}
+```

--- a/mbed-drivers/v2/EphemeralBuffer.hpp
+++ b/mbed-drivers/v2/EphemeralBuffer.hpp
@@ -1,0 +1,144 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DRIVERS_EPHEMERAL_BUFFER_H
+#define MBED_DRIVERS_EPHEMERAL_BUFFER_H
+
+#include <cstdint>
+#include <cstring>
+#include "mbed-drivers/Buffer.h"
+
+namespace mbed {
+namespace drivers {
+namespace v2 {
+/**
+ * The EphemeralBuffer class is a variant of the Buffer class.
+ * Instead of just storing a buffer pointer and a size, if the buffer is less than ```sizeof(size_t) + sizeof(void *)```
+ * bytes long, it packs the whole buffer into the space occupied by the pointer and size variable. This is indicated by
+ * setting the MSB in size.
+ *
+ * EphemeralBuffer is not assumed to own the buffer to which it points unless it
+ * is in ephemeral mode.
+ */
+class EphemeralBuffer {
+public:
+    /**
+     * @brief Default constructor
+     * Initializes the EphemeralBuffer to ephemeral mode with a buffer length of
+     * 7. This means that a default EphemeralBuffer can be used to receive data
+     * or as the target of a copy operation.
+     */
+    EphemeralBuffer() : _len(sizeof(_data)), _ephemeral(true) {}
+
+    /**
+     * @brief Copy constructor
+     * Duplicates the incoming EphemeralBuffer.
+     *
+     * @param[in] x the buffer to copy
+     */
+    EphemeralBuffer(const EphemeralBuffer & x) : _ephemeral(x._ephemeral)
+    {
+        if (is_ephemeral()) {
+            _len = x._len;
+            std::memcpy(_data, x._data, sizeof(_data));
+        } else {
+            _dataPtr = const_cast<void *>(x._dataPtr);
+            _ptrLen  = x._ptrLen;
+        }
+    }
+
+    /**
+     * Set buffer pointer and length.
+     *
+     * @param[in] b A buffer to duplicate
+     */
+    void set(const Buffer & b);
+
+    /**
+     * Set buffer pointer and length.
+     * If the buffer is 7 or fewer bytes, copy it into the contents of EphemeralBuffer
+     * instead of keeping a pointer to it.
+     *
+     * @param[in] b A buffer to duplicate
+     */
+    void set_ephemeral(const Buffer & b);
+
+    /**
+     * Set the buffer pointer and length
+     *
+     * @param[in] buf the buffer pointer to duplicate
+     * @param[in] len the length of the buffer to duplicate
+     */
+    void set(void *buf, std::size_t len);
+
+    /**
+     * Set buffer pointer and length.
+     * If the buffer is 7 or fewer bytes, copy it into the contents of EphemeralBuffer
+     * instead of keeping a pointer to it.
+     *
+     * @param[in] buf the buffer pointer to duplicate
+     * @param[in] len the length of the buffer to duplicate
+     */
+    void set_ephemeral(void *buf, std::size_t len);
+
+    /**
+     * Get a pointer to the buffer.
+     *
+     * If the buffer is the internal storage, return it, otherwise return the reference
+     *
+     * @return the buffer pointer
+     */
+    void * get_buf();
+
+    /**
+     * Get the length
+     *
+     * @return the length of the buffer
+     */
+    std::size_t get_len() const;
+
+    /**
+     * Check if the buffer is ephemeral.
+     *
+     * @retval true The buffer contains data, rather than a pointer
+     * @retval false The buffer contains a pointer to data
+     */
+    bool is_ephemeral() const;
+
+protected:
+    union {
+        struct {
+            void * _dataPtr;
+            std::size_t _ptrLen:(sizeof(size_t)*8-1);
+            unsigned _reserved:1;
+        };
+        struct {
+            std::uint8_t _data[sizeof(void *) + sizeof(size_t) - 1];
+            std::size_t _len:7;
+            unsigned _ephemeral:1;
+        };
+    };
+public:
+    /**
+     * A constant that indicates the maximum size of the buffer in ephemeral mode.
+     */
+    static constexpr size_t ephemeralSize = sizeof(_data);
+
+};
+} // namespace v2
+} // namespace drivers
+} // namespace mbed
+#endif // MBED_DRIVERS_EPHEMERAL_BUFFER_H

--- a/mbed-drivers/v2/I2C.hpp
+++ b/mbed-drivers/v2/I2C.hpp
@@ -1,0 +1,606 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DRIVERS_V1_I2C_HPP
+#define MBED_DRIVERS_V1_I2C_HPP
+
+#include "mbed-drivers/platform.h"
+
+#if DEVICE_I2C && DEVICE_I2C_ASYNCH
+
+
+#include "mbed-hal/i2c_api.h"
+#include "mbed-hal/dma_api.h"
+
+#include "mbed-drivers/CThunk.h"
+#include "core-util/FunctionPointer.h"
+#include "core-util/PoolAllocator.h"
+
+// Forward declarations
+namespace mbed {
+namespace drivers {
+namespace v2 {
+enum class I2CError;
+} // namespace mbed
+} // namespace drivers
+} // namespace v2
+
+#include "I2CDetail.hpp"
+#include "EphemeralBuffer.hpp"
+
+/// There are 4 possible I2C Events, so limit the I2C transaction handlers to 4
+const size_t I2C_TRANSACTION_NHANDLERS = 4;
+
+/**
+ * \file
+ * \brief A generic interface for I2C peripherals
+ *
+ * The I2C class interfaces with an I2C Resource manager in order to initiate Transactions and receive events. The
+ * I2CTransaction class encapsulates all I2C transaction parameters. The I2CResourceManager class is a generic interface
+ * for implementing I2C resource managers. This will allow for additional classes of I2C device, for example, a
+ * bitbanged I2C master.
+ *
+ * # I2C
+ * I2C encapsulates an I2C master. The physical I2C master to use is selected via the pins provided to the constructor.
+ * The ```frequency()``` API sets the default frequency for transactions issued from the I2C object. This is used for
+ * each transaction issued by I2C unless overridden when creating the transaction. Transactions are initiated by calling
+ * ```transfer_to()``` or ```transfer_to_irqsafe()```. Both of these APIs create an instance of the ```TransferAdder```
+ * helper class.
+ *
+ * # TransferAdder
+ * The TransferAdder class allows convenient construction of complex transfers.
+ *
+ * The ```frequency()``` member overrides the default frequency set by the issuing I2C object.
+ *
+ * The ```on()``` member allows setting up to 4 event handlers, each with a corresponding event mask.
+ *
+ * The ```tx()``` members add a buffer to send to the transfer.
+ *
+ * The ```rx()``` members add a buffer to receive into to the transfer. There is a special case of ```rx()```, which
+ * doesn't use a normal buffer. When ```rx(size_t)``` is called with a size of less than 8 bytes, the underlying
+ * EphermeralBuffer is placed in ephemeral mode. This means that no preallocated receive buffer is needed, instead the
+ * data is packed directly into the EphemeralBuffer. This has a side-effect that the data will be freed once the last
+ * event handler has exited, so if the data must be retained, it should be copied out.
+ *
+ * The ```apply()``` method validates the transfer and adds it to the transaction queue of the I2CResourceManager. It
+ * returns the result of validation.
+ *
+ * # I2C Resource Managers
+ * I2C Resource managers are instantiated statically and initialized during global init. There is one Resource Manager
+ * per logical I2C master. Logical I2C masters could consist of:
+ *
+ * * Onchip I2C masters
+ * * I2C Bridges (SPI->I2C bridge, I2C->I2C bridge, etc.)
+ * * Bit banged I2C
+ * * Bit banged I2C over SPI GPIO expander
+ * * More...
+ *
+ * Currently only onchip I2C masters are supported.
+ *
+ * # I2C transactions
+ * An I2CTransaction contains a list of event handlers and their event masks, an I2C address, an operating frequency,
+ * and zero or more I2CSegments. Zero-segment Transactions are explicitly supported since they are useful in connected
+ * device discovery (pings).
+ *
+ * # I2C Segments
+ * An I2CSegment is a wrapper around an EphemeralBuffer. It provides an I2C transfer direction (read or write) and an
+ * optional callback to execute in IRQ context. I2CSegments also provide a chaining pointer so that they can perform
+ * sequential or scatter/gather operations.
+ *
+ * # Constructing I2C transactions
+ *
+ * ```C++
+ * void doneCB(bool dir, I2CTransaction *t, uint32_t event) {
+ *     // Do something
+ * }
+ * I2C i2c0(sda, scl);
+ * void app_start (int, char **) {
+ *     uint8_t cmd[2] = {0xaa, 0x55};
+ *     i2c0.transfer_to(addr).tx(cmd,2).rx(4).on(I2C_EVENT_ALL, doneCB);
+ * }
+ * ```
+ */
+namespace mbed {
+namespace drivers {
+namespace v2 {
+// Forward declaration of I2C
+class I2C;
+
+/**
+ * @brief List of error codes that can be produced by the I2C API
+ */
+enum class I2CError {
+    None,
+    InvalidMaster,
+    PinMismatch,
+    Busy,
+    NullTransaction,
+    NullSegment,
+    MissingPoolAllocator,
+    InvalidAddress,
+    BufferSize,
+    ScatterGatherNotSupported,
+    DeinitInProgress
+};
+
+/**
+ * A Transaction container for I2C
+ */
+class I2CTransaction {
+public:
+    /** I2C transfer callback
+     *  @param The transaction that was running when the callback was triggered
+     *  @param the event that triggered the calback
+     */
+    using event_callback_t = detail::I2C_event_callback_t;
+
+    /**
+     * Construct an I2C transaction and set the destination address at the same time
+     *
+     * @param[in] address set the I2C destination address
+     */
+    I2CTransaction(uint16_t address, uint32_t hz, bool irqsafe, I2C *issuer);
+    ~I2CTransaction();
+
+    /**
+     * Get a new segment to be used by the transaction.
+     * This API calls the associated I2C object's associated allocator.
+     * @return a new I2CSegment
+     */
+    detail::I2CSegment * new_segment();
+
+    /**
+     * Install a new event handler with the corresponding event mask
+     * Once all available event slots are consumed, further calls to add_event are ignored.
+     *
+     * @param[in] event The event mask on which to trigger cb
+     * @param[in] cb The event to trigger when one or more bits in the event mask is matched
+     * @retval false There was no space for a new event handler
+     * @retval true The new event handler was installed
+     */
+    bool add_event(uint32_t event, const event_callback_t & cb);
+
+    /**
+     * The resource manager calls this API.
+     * Calls the event handlers and
+     */
+    void process_event(uint32_t event);
+
+    /**
+     * Set the next transaction in the queue
+     * This is an atomic operation that will append to the queue.
+     */
+    void append(I2CTransaction *t);
+
+    /**
+     * Forwards the irq-context callback to the segment
+     * Also adds a pointer to this transaction to the callback
+     * @param[in] the event that triggered this callback
+     */
+    void call_irq_cb(uint32_t event);
+
+    /**
+     * If the current segment is valid advance the segment pointer
+     *
+     * @retval true if the current segment is valid after this operation
+     * @retval false if the current segment is not valid after this operation
+     */
+    bool advance_segment();
+
+    /**
+     * Reset the current segment to the root segment
+     */
+    void reset_current()
+    {
+        _current  = _root;
+    }
+
+    /**
+     * Accessor for the next pointer
+     * @return the next transaction
+     */
+    I2CTransaction * get_next()
+    {
+        return _next;
+    }
+
+    /**
+     * Accessor for the Transactions's issuer
+     * @return the I2C object that issued this transaction
+     */
+    I2C * get_issuer()
+    {
+        return _issuer;
+    }
+
+    /**
+     * Accessor for the current segment pointer
+     * @return the current segment poitner
+     */
+    detail::I2CSegment * get_current()
+    {
+        return _current;
+    }
+
+    /**
+     * Accessor for the irqsafe flag
+     * @retval true if the transaction was instantiated with irqsafe set and access to irq-safe allocators
+     * @retval false if the transaction was not instantiated with irqsafe set and access to irq-safe allocators
+     */
+    bool is_irqsafe() const
+    {
+        return _irqsafe;
+    }
+
+    /**
+     * Accessor for the transaction frequency
+     * @return the frequency of the transaction in Hz
+     */
+    uint32_t frequency() const
+    {
+        return _hz;
+    }
+
+    /**
+     * Accessor for the transaction frequency
+     * @param[in] hz the transaction frequency in Hz
+     */
+    void frequency(uint32_t hz)
+    {
+        _hz = hz;
+    }
+
+    /**
+     * Accessor for the transaction target address
+     * @return the transaction address
+     */
+    uint16_t address() const
+    {
+        return _address;
+    }
+
+protected:
+    /**
+     * The next transaction in the queue
+     * This field is used for chaining transactions together into a queue.
+     *
+     * This field is not volatile because it is only accessed from within a
+     * critical section.
+     */
+    I2CTransaction * _next;
+    /// The target I2C address to communicate with
+    uint16_t _address;
+    /**
+     * The first I2CSegment in the transaction
+     *
+     * This field is not volatile because it is only accessed from within a
+     * critical section. This will still be valid if the critical section is
+     * replaced with an atomic operation.
+     */
+    detail::I2CSegment * _root;
+    /**
+     * The first I2CSegment in the transaction
+     *
+     * This is a helper field for building or processing I2C transactions.
+     * It allows the Transaction to easily locate the end of the queue when
+     * composing the transaction and, equally, the currently transferring segment
+     * while processing the transaction.
+     *
+     * This field is not volatile because it is only accessed from within a
+     * critical section.
+     */
+    detail::I2CSegment * _current;
+    /// The I2C frequency to use for the transaction
+    unsigned _hz;
+    /// Flag to indicate that the Transaction and its Segments were allocated with an irqsafe allocator
+    bool _irqsafe;
+    /// The I2C Object that launched this transaction
+    I2C * _issuer;
+    /// An array of I2C Event Handlers.
+    detail::I2CEventHandler _handlers[I2C_TRANSACTION_NHANDLERS];
+};
+
+/** An I2C Master, used for communicating with I2C slave devices
+ *
+ * Example:
+ * @code
+ * // Read 6 bytes from I2C EEPROM slave at address 0x62
+ *
+ * #include "mbed.h"
+ *
+ * mbed::drivers::v2::I2C i2c(p28, p27);
+ *
+ * // This callback executes in minar context
+ * void xfer_done(mbed::drivers::v2::I2CTransaction * t, int event) {
+ *     t->reset_current(); // Set the current pointer to root.
+ *     uint8_t *txPtr = t->get_current->get_buf();
+ *     printf("EEPROM 0x%02x@0x%02x%02x: ", t->address(), txPtr[0], txPtr[1]);
+ *     // Get the rx buffer pointer
+ *     uint8_t * rxPtr = t->get_current() // get the first segment (the tx segment)
+ *                        ->get_next()    // get the second segment (the rx segment)
+ *                        ->get_buf();    // get the buffer pointer
+ *     for (uint i = 0; i < 6; i++) {
+ *         printf("%02x", rxPtr[i]);
+ *     }
+ *     printf("\n");
+ *     // Both the tx and rx buffers are ephemeral, so they will be freed automatically when this function exits
+ * }
+ *
+ * void app_start(int, char **) {
+ *     i2c.transfer_to(0x62)            // I2C Slave Address
+ *         .tx_ephemeral("\x12\x34", 2) // Send EEPROM location
+ *         .rx(6)                       // Read 6 bytes into an ephemeral buffer
+ *         .on(I2C_EVENT_TRANSFER_COMPLETE, xfer_done)
+ *         .apply();
+ * }
+ * @endcode
+ */
+class I2C {
+public:
+    using event_callback_t = detail::I2C_event_callback_t;
+
+    /** Create an I2C Master interface, connected to the specified pins
+     *
+     *  @param sda I2C data line pin
+     *  @param scl I2C clock line pin
+     */
+    I2C(PinName sda, PinName scl);
+
+    /** Create an I2C Master interface, connected to the specified pins and providing IRQ-safe allocators
+     *
+     *  @param sda I2C data line pin
+     *  @param scl I2C clock line pin
+     *  @param TransactionPool An IRQ-safe allocator for Transaction objects
+     *  @param SegmentPool An IRQ-safe allocator for Segment objects
+     */
+    I2C(PinName sda, PinName scl, mbed::util::PoolAllocator *TransactionPool, mbed::util::PoolAllocator *SegmentPool);
+
+    /** Destroy the I2C Master interface.
+     *  Releases a reference to the I2C Resource Manager
+     */
+    ~I2C();
+
+    /** Set the frequency of the I2C interface
+     *
+     *  @param hz The bus frequency in hertz
+     */
+    void frequency(uint32_t hz);
+
+    /**
+     * @brief A helper class for constructing transactions
+     */
+    class TransferAdder {
+        friend I2C;
+    protected:
+        /**
+         * @brief Construct a new TransferAdder
+         *
+         * @param[in] i2c the issuing I2C object
+         * @param[in] address the address that is the target of the transfer
+         * @param[in] hz the frequency to use for the transfer
+         * @param[in] irqsafe indicates whether the TransferAdder should use the I2C Object's IRQ-safe allocators
+         */
+        TransferAdder(I2C *i2c, int address, uint32_t hz, bool irqsafe);
+
+        /**
+         * @brief Allocates and constructs a new I2C Segment
+         * @return A new I2C Segment
+         */
+        detail::I2CSegment * new_segment(detail::I2CDirection d);
+
+    public:
+        /**
+         * @brief Set the frequency for this transaction
+         *
+         * By default, the transaction will use the default frequency for the I2C object. This overrides that frequency.
+         * The frequency used will be applied to the whole transaction, not just a single segment.
+         *
+         * @param[in] hz the frequency to set
+         */
+        TransferAdder & frequency(uint32_t hz);
+
+        /**
+         * @brief set an event handler
+         *
+         * An event is triggered when any of the bits in the event mask match the event.
+         * Four event slots are provided, additional event
+         *
+         * @param[in] event the event mask
+         * @param[in] cb the callback to trigger on an event mask match
+         */
+        TransferAdder & on(uint32_t event, const event_callback_t & cb);
+
+        /**
+         * @brief set an event handler
+         *
+         * An event is triggered when any of the bits in the event mask match the event.
+         * Four event slots are provided, additional event
+         *
+         * @param[in] event the event mask
+         * @param[in] cb the callback to trigger on an event mask match
+         */
+        TransferAdder & on(uint32_t event, event_callback_t && cb);
+
+        /**
+         * @brief Queue the transfer
+         *
+         * Hands the transfer over to the resource manager and returns the resource manager's status. No further
+         * configuration of the transfer is possible after apply() has been called.
+         *
+         * @return the error status of submitting the transfer to the resource manager
+         */
+        I2CError apply();
+
+        /**
+         * @brief Add a transmit buffer to the transaction
+         *
+         * @param[in] buf a pointer to the buffer to send
+         * @param[in] len the number of bytes to send
+         */
+        TransferAdder & tx(void *buf, size_t len);
+
+        /**
+         * @brief Add a transmit buffer to the transaction
+         *
+         * @param[in] buf a pointer to and length of the buffer to send
+         */
+        TransferAdder & tx(const Buffer & buf);
+
+        /**
+         * @brief Add an ephermeral transmit buffer to the transaction
+         *
+         * If the buffer is 7 or fewer bytes, it will be managed internally, so the original can be freed.
+         *
+         * @param[in] buf a pointer to the buffer to send
+         * @param[in] len the number of bytes to send
+         */
+        TransferAdder & tx_ephemeral(void *buf, size_t len);
+
+        /**
+         * @brief Add a receive buffer to the transaction
+         *
+         * @param[in] buf a pointer to the buffer to receive into
+         * @param[in] len the number of bytes to receive
+         */
+        TransferAdder & rx(void *buf, size_t len);
+
+        /**
+         * @brief Add a receive buffer to the transaction
+         *
+         * @param[in] buf a pointer to and length of the buffer to receive into
+         */
+        TransferAdder & rx(const Buffer & buf);
+
+        /**
+         * @brief Add an ephermeral receive buffer to the transaction
+         *
+         * If the buffer is 7 or fewer bytes, it will be managed internally
+         *
+         * @param[in] len the number of bytes to receive
+         */
+        TransferAdder & rx(size_t len);
+
+        /**
+         * @brief Applies an unapplied transaction or destroys a failed transaction
+         *
+         * If the transaction has not been applied when the TransferAdder goes out of scope, it is automatically
+         * applied. If it has already been applied, the destructor exits. If an error condition has been detected, the
+         * destructor destroys the transaction and any associated segments.
+         */
+        ~TransferAdder();
+    protected:
+        /// The transaction object that is to be added to the I2C transaction queue
+        I2CTransaction * _xact;
+        /// The I2C object to use for posting the transaction
+        I2C* _i2c;
+        /// flag variable to prevent double-posting of transactions
+        bool _posted;
+        /// flag variable to indicate whether the transaction is intended to use irq-safe allocators
+        bool _irqsafe;
+        /// The error status of the TransferAdder. Transaction will only be posted if the error status is I2CError::none
+        I2CError _rc;
+    };
+
+    /**
+     * @brief Begin constructing a transfer to the specified I2C address
+     *
+     * Creates a TransferAdder to manage the construction of the transfer. This API should not be called from IRQ
+     * context
+     *
+     * @param[in] address the I2C address that is the target of this transaction
+     */
+    TransferAdder transfer_to(int address);
+
+    /**
+     * @brief Begin constructing a transfer to the specified I2C address, in irq context
+     *
+     * Creates a TransferAdder to manage the construction of the transfer. This API can be called from IRQ context, but
+     * It requires that a pool allocators for both Transactions and Segments have been specified.
+     *
+     * @param[in] address the I2C address that is the target of this transaction
+     */
+    TransferAdder transfer_to_irqsafe(int address);
+
+    /**
+     * @brief Create a new segment
+     *
+     * If irqsafe = true, allocate from a pool allocator. Otherwise, allocate from new.
+     *
+     * @param[in] irqsafe flag that indicates whether or not to use a pool allocator
+     * @return the new segment on success, or NULL on failure
+     */
+    detail::I2CSegment * new_segment(bool irqsafe);
+
+    /**
+     * @brief Free a transaction
+     *
+     * Determines destroys and frees a transaction. If the transaction was marked irqsafe, calls the destructor then the
+     * pool allocator's free member function. If the transaction was not marked irqsafe, calls delete.
+     *
+     * @param[in] t the transaction to destroy and free
+     */
+    void free(I2CTransaction *t);
+
+    /**
+     * @brief Free a segment
+     *
+     * Determines destroys and frees a segment. If irqsafe = true, calls the destructor then the
+     * pool allocator's free member function. If irqsafe = false, calls delete.
+     *
+     * @param[in] s the segment to destroy and free
+     * @param[in] irqsafe a flag that indicates whether to use the pool allocator to free or not
+     */
+    void free(detail::I2CSegment *s, bool irqsafe);
+
+protected:
+    friend TransferAdder;
+
+    /**
+     * @brief Initiate a transaction
+     *
+     * Submits the transaction to the resource manager's queue and returns the result
+     *
+     * @param[in] t the transaction to queue
+     * @return the status of the submission
+     */
+    I2CError post_transaction(I2CTransaction *t);
+
+    /**
+     * @brief Creates a new transaction and pre-fills some parts of it.
+     *
+     * new_transaction prefills the address, frequency, and issuer fields. If marked irqsafe, it will be allocated from
+     * the pool allocator and any associated segments will be allocated from the pool allocator as well.
+     *
+     * @param[in] address The I2C address that is the target of this transaction
+     * @param[in] hz The I2C frequency to use
+     * @param[in] irqsafe The flag that indicates whether to use pool allocators
+     * @param[in] issuer A pointer to this I2C instance
+     * @return the new I2C Transaction object, or NULL on failure
+     */
+    I2CTransaction * new_transaction(uint16_t address, uint32_t hz, bool irqsafe, I2C *issuer);
+
+    uint32_t _hz;
+    detail::I2CResourceManager * _owner;
+    mbed::util::PoolAllocator * TransactionPool;
+    mbed::util::PoolAllocator * SegmentPool;
+};
+} // namespace v2
+} // namespace drivers
+} // namespace mbed
+
+#endif
+
+#endif // MBED_DRIVERS_V1_I2C_HPP

--- a/mbed-drivers/v2/I2CDetail.hpp
+++ b/mbed-drivers/v2/I2CDetail.hpp
@@ -1,0 +1,347 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DRIVERS_V1_I2CDETAIL_HPP
+#define MBED_DRIVERS_V1_I2CDETAIL_HPP
+
+#include "mbed-drivers/platform.h"
+
+#if DEVICE_I2C && DEVICE_I2C_ASYNCH
+
+#include "EphemeralBuffer.hpp"
+#include "core-util/FunctionPointer.h"
+#include "PinNames.h"
+
+namespace mbed {
+namespace drivers {
+namespace v2 {
+// Forward declaration of the I2CTransaction
+class I2CTransaction;
+
+namespace detail {
+enum class I2CDirection {Transmit, Receive};
+
+/** I2C transfer callback
+ *  @param The transaction that was running when the callback was triggered
+ *  @param The event that triggered the calback
+ */
+typedef mbed::util::FunctionPointer2<void, I2CTransaction *, uint32_t> I2C_event_callback_t;
+
+/**
+ * @brief A class that contains the information requires for an individial chunk of an I2C transaction
+ *
+ * I2CTransaction can be composed of several segments, each of which can be either transmit or receive segments. The
+ * segments are formed into a linked list through the _next pointer. Each segment can have an associated callback that
+ * executes in IRQ context. This allows for I2C transactions to be modified on the fly. For example, it might be useful
+ * in some protocols to read a length, then transfer the number of bytes specified by the length.
+ */
+class I2CSegment : public EphemeralBuffer {
+public:
+    /**
+     * I2C transfer callback
+     * @param The segment that was running when the callback was triggered
+     * @param The event that triggered the calback
+     */
+    using IRQCallback = mbed::util::FunctionPointer2<void, I2CSegment *, uint32_t>;
+    I2CSegment() :
+        EphemeralBuffer(), _next(nullptr), _irqCB(nullptr)
+    {}
+
+    /**
+     * @brief Copies an existing I2CSegment
+     *
+     * Copying the underlying EphermeralBuffer has two different operations:
+     *
+     * * If the buffer is in ephemeral mode, it duplicates the data
+     * * If it is not in ephemeral mode, it duplicates the pointer.
+     *
+     * Following segments are not duplicated.
+     *
+     * @param[in] s the I2CSegment to copy
+     */
+    I2CSegment(const I2CSegment & s) :
+        EphemeralBuffer(static_cast<const EphemeralBuffer &>(s)), _dir(s._dir), _next(nullptr), _irqCB(s._irqCB)
+    {}
+
+    /**
+     * @brief Move constructor
+     *
+     * Steals the references from the incoming rvalue reference
+     * @param[in] rref The I2CSegment to move from
+     */
+    I2CSegment(I2CSegment && rref) :
+        EphemeralBuffer(static_cast<EphemeralBuffer &&>(rref)), _dir(rref._dir), _next(rref._next), _irqCB(rref._irqCB)
+    {}
+
+    /**
+     * @brief Set the following I2CSegment.
+     *
+     * In an I2CTransaction, this allows composition of a complex I2C transfer
+     * @param[in] next an I2CSegment to append to the current one
+     */
+    void set_next(I2CSegment *next)
+    {
+        _next = next;
+    }
+
+    /**
+     * @brief get a pointer to the next I2CSegment
+     *
+     * @return If another segment is appended, a pointer to that segment,
+     * otherwise nullptr
+     */
+    I2CSegment * get_next() const
+    {
+        return _next;
+    }
+
+    /**
+     * @brief Set the callback to execute immediately when this segment is
+     * completed.
+     *
+     * This should typically be nullptr. No event filtering is provided on the
+     * irq callback.
+     * @param[in] cb the FunctionPointer to call when this segment completes
+     */
+    void set_irq_cb(IRQCallback cb)
+    {
+        _irqCB = cb;
+    }
+
+    /**
+     * @brief Trigger the attached callback
+     *
+     * If there is an attached irq-context callback, call it with the incoming
+     * event and the this pointer.
+     *
+     * @param[in] event the event which caused this callback.
+     */
+    void call_irq_cb(uint32_t event)
+    {
+        if (_irqCB) {
+            _irqCB(this, event);
+        }
+    }
+
+    /**
+     * @brief Set the direction of the I2C transfer
+     *
+     * Set whether this segment is a transmit segment or a receive segment.
+     *
+     * @param[in] dir the direction of the transfer
+     */
+    void set_dir(I2CDirection dir)
+    {
+        _dir = dir;
+    }
+
+    /**
+     * @brief Read the transfer direction
+     *
+     * @retval I2CDirection::Transmit this segment is a transmission segment
+     * @retval I2CDirection::Receive this segment is a reception segment
+     */
+    I2CDirection get_dir() const
+    {
+        return _dir;
+    }
+
+protected:
+    enum I2CDirection _dir;         ///< Direction of the transfer
+    I2CSegment *      _next;        ///< Next segment to execute
+    IRQCallback       _irqCB;       ///< Callback to execute in irq context
+};
+
+/**
+ * @brief The base resource manager class for I2C
+ *
+ * The I2CResourceManager manager is a multiplexer that guarantees mutually exclusive access to the underlying hardware
+ * I2C master. It does this by serializing transactions and ensuring that they are processed atomically. This way, there
+ * can be many users of the I2C bus, without access conflicts.
+ *
+ * The I2CResourceManager is the interface required to manage a particular I2C master. It provides several common
+ * operations, but explicitly does not permit copy or move construction or assignment.
+ *
+ * The common operations provided by the Resource manager are:
+ *
+ * * Adding a transaction to the queue
+ * * Processing an event
+ *
+ * These operations are common to all resource managers, so they are provided by the interface class.
+ *
+ * ## Event Handling overview
+ *
+ * When an interrupt occurs, the HAL processes it; if anything needs to be handled by the upper layers, an event is
+ * generated. The derived resource manager should call I2CResourceManager::process_event with this event. If
+ * appropriate, the I2CResourceManager will call the I2CSegment's irq callback handler.
+ *
+ * The resource manager handles events according to the following pseudocode:
+ *
+ * ```
+ * If there is an error condition:
+ *     Schedule handle_event() with the current transaction and event
+ * Otherwise, if there are more segments to process:
+ *     Start the next segment
+ * Otherwise,
+ *     Schedule handle_event() with the current transaction and the done flag
+ * If another segment was not started,
+ *     Start the next transaction
+ * ```
+ *
+ * handle_event() calls the registered event handlers for the current transaction, then frees the Transaction, using the
+ * I2C object that originally issued the transaction.
+ */
+class I2CResourceManager {
+public:
+    /* Copying and moving Resource Managers would have unpredictable results, so copy and move constructors are
+     * explicitly deleted.
+     */
+    I2CResourceManager(const I2CResourceManager&) = delete;
+    I2CResourceManager(I2CResourceManager&&) = delete;
+    const I2CResourceManager& operator =(const I2CResourceManager&) = delete;
+    const I2CResourceManager& operator =(I2CResourceManager&&) = delete;
+
+    /**
+     * @brief Initialize the I/O pins
+     *
+     * While the resource manager is initialized statically, it may need runtime initialization as well. init is called
+     * each time a new I2C object is created.
+     *
+     * @param[in] sda the SDA pin of the I2C master to bind
+     * @param[in] scl the SCL pin of the I2C master to bind
+     */
+    virtual I2CError init(PinName sda, PinName scl) = 0;
+    /**
+     * Release a reference to the I2CResourceManager
+     */
+    virtual void release() = 0;
+
+    /**
+     * @brief Add a transaction to the transaction queue of the associated logical I2C port
+     *
+     * @param[in] transaction Queue this transaction
+     * @return the result of validating the transaction
+     */
+    I2CError post_transaction(I2CTransaction *transaction);
+
+protected:
+    /* These APIs are the interfaces that must be supplied by a derived Resource Manager */
+    /**
+     * @brief Starts the transaction at the head of the queue
+     */
+    virtual I2CError start_transaction() = 0;
+
+    /**
+     * @brief Starts the next segment
+     */
+    virtual I2CError start_segment() = 0;
+
+    /**
+     * @brief Validates the transaction according to the criteria of the derived Resource Manager
+     * @param[in] transaction the transaction to validate
+     */
+    virtual I2CError validate_transaction(I2CTransaction *transaction) const = 0;
+
+protected:
+    /**
+     * @brief Process an event
+     *
+     * Handles the mechanics of processing an event, including
+     * * handling errors
+     * * Triggering any irq callback
+     * * (optionally) scheduling an event handler using handle_event
+     * * (optionally) advancing to the next transaction
+     * * starting the next segment
+     *
+     * @param[in] event the source of the current handler call
+     */
+    void process_event(uint32_t event);
+
+    /**
+     * @brief Handle an event
+     *
+     * Distributes the event and transaction that triggered it to any event handler with a matching event mask, then
+     * deletes the transaction, using the method specified by the issuing I2C object
+     *
+     * @param[in] t the transaction that was in progress when the event was triggered
+     * @param[in] event the event(s) that occurred
+     */
+    void handle_event(I2CTransaction *t, uint32_t event);
+
+    /**
+     * @brief The resource manager constructor.
+     *
+     * Resource managers may not be copied or moved. The resource manager must be inherited.
+     */
+    I2CResourceManager();
+
+    /**
+     * The I2CResourceManager destructor. It is not expected that the destructor will be called, however, the destructor
+     * handles cleanup of resources such as deleting any pending transactions.
+     */
+    ~I2CResourceManager();
+
+    // The head of the transaction queue
+    I2CTransaction * volatile _TransactionQueue;
+};
+
+I2CResourceManager * get_i2c_owner(int I);
+
+/**
+ * @brief A helper class for holding a callback and an event mask
+ */
+class I2CEventHandler {
+public:
+    /**
+     * @brief Constructor for I2CEventHandler
+     *
+     * Sets the event mask to 0 and the callback to null
+     */
+    I2CEventHandler();
+
+    /**
+     * @brief Handle an event
+     *
+     * If event & _event_mask is non-zero, calls the event handler, otherwise does nothing
+     *
+     * @param[in] t the transaction that was in progress when the event was triggered
+     * @param[in] event the event(s) that occurred
+     */
+    void call(I2CTransaction *t, uint32_t event);
+
+    /**
+     * @brief Set the callback and the event that event mask
+     *
+     * @param[in] cb the callback to trigger when the event mask is matched
+     * @param[in] event The event mask to use to filter events
+     */
+    void set(const I2C_event_callback_t &cb, uint32_t event);
+
+    /**
+     * @brief Test if the event mask is non-zero and the callback is bound
+     */
+    operator bool() const;
+protected:
+    I2C_event_callback_t _cb;
+    uint32_t _eventmask;
+};
+
+} // namespace detail
+} // namespace v2
+} // namespace drivers
+} // namespace mbed
+#endif // DEVICE_I2C && DEVICE_I2C_ASYNCH
+
+#endif // MBED_DRIVERS_V1_I2CDETAIL_HPP

--- a/source/v2/EphemeralBuffer.cpp
+++ b/source/v2/EphemeralBuffer.cpp
@@ -1,0 +1,79 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mbed-drivers/v2/EphemeralBuffer.hpp"
+#include <cstring>
+namespace mbed {
+namespace drivers {
+namespace v2 {
+
+void EphemeralBuffer::set(const Buffer & b)
+{
+    set(b.buf,b.length);
+}
+
+void EphemeralBuffer::set(void *buf, size_t len)
+{
+    _ephemeral = false;
+    _ptrLen = len;
+    _dataPtr = buf;
+}
+
+void EphemeralBuffer::set_ephemeral(const Buffer & b)
+{
+    set_ephemeral(b.buf,b.length);
+}
+
+void EphemeralBuffer::set_ephemeral(void *buf, size_t len)
+{
+    if (len <= sizeof(_data)) {
+        _ephemeral = true;
+        _len = len;
+        if (buf) {
+            std::memcpy(_data, buf, len);
+        }
+    } else {
+        _ephemeral = false;
+        _ptrLen = len;
+        _dataPtr = buf;
+    }
+}
+
+void * EphemeralBuffer::get_buf()
+{
+    if (_ephemeral) {
+        return _data;
+    } else {
+        return _dataPtr;
+    }
+}
+
+size_t EphemeralBuffer::get_len() const
+{
+    if (_ephemeral) {
+        return _len;
+    } else {
+        return _ptrLen;
+    }
+}
+
+bool EphemeralBuffer::is_ephemeral() const
+{
+    return _ephemeral;
+}
+} // namespace v2
+} // namespace drivers
+} // namespace mbed

--- a/source/v2/I2C.cpp
+++ b/source/v2/I2C.cpp
@@ -1,0 +1,372 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mbed-drivers/v2/I2C.hpp"
+#include "mbed-drivers/v2/EphemeralBuffer.hpp"
+#include "minar/minar.h"
+#include "ualloc/ualloc.h"
+#include "core-util/CriticalSectionLock.h"
+#include "PeripheralPins.h"
+
+#if DEVICE_I2C && DEVICE_I2C_ASYNCH
+
+namespace mbed {
+namespace drivers {
+namespace v2 {
+
+I2CTransaction::I2CTransaction(uint16_t address, uint32_t hz, bool irqsafe, I2C *issuer):
+    _next(nullptr),
+    _address(address),
+    _root(nullptr),
+    _current(nullptr),
+    _hz(hz),
+    _irqsafe(irqsafe),
+    _issuer(issuer)
+{}
+
+I2CTransaction::~I2CTransaction()
+{
+    mbed::util::CriticalSectionLock lock;
+    _current = _root;
+    while (_current) {
+        detail::I2CSegment * next = _current->get_next();
+        _issuer->free(_current, _irqsafe);
+        _current = next;
+    }
+}
+
+void I2CTransaction::append(I2CTransaction *t)
+{
+    CORE_UTIL_ASSERT(t != nullptr);
+    if (!t) {
+        return;
+    }
+    // Append is called from within a critical section, so an atomic_cas is not necessary
+    if (_next == nullptr) {
+        _next = t;
+    } else {
+        _next->append(t);
+    }
+}
+
+void I2CTransaction::call_irq_cb(uint32_t event)
+{
+    if (_current) {
+        _current->call_irq_cb(event);
+    }
+}
+
+bool I2CTransaction::advance_segment()
+{
+    if (!_current) {
+        return false;
+    }
+    _current = _current->get_next();
+    return _current != nullptr;
+}
+
+detail::I2CSegment * I2CTransaction::new_segment()
+{
+    detail::I2CSegment * s = _issuer->new_segment(_irqsafe);
+    CORE_UTIL_ASSERT(s != nullptr);
+    if (!s) {
+        return nullptr;
+    }
+    s->set_next(nullptr);
+    mbed::util::CriticalSectionLock lock;
+    if (_root == nullptr) {
+        _root = s;
+        _current = s;
+    } else {
+        _current->set_next(s);
+        _current = s;
+    }
+    return s;
+}
+
+bool I2CTransaction::add_event(uint32_t event, const event_callback_t & cb)
+{
+    size_t i;
+    for (i = 0; i < I2C_TRANSACTION_NHANDLERS; i++) {
+        if (!_handlers[i]) {
+            _handlers[i].set(cb, event);
+            break;
+        }
+    }
+    return i < I2C_TRANSACTION_NHANDLERS;
+}
+
+void I2CTransaction::process_event(uint32_t event)
+{
+    size_t i;
+    for (i = 0; i < I2C_TRANSACTION_NHANDLERS; i++) {
+        if (_handlers[i]) {
+            _handlers[i].call(this, event);
+        }
+    }
+}
+
+I2C::I2C(PinName sda, PinName scl) :
+    _hz(100000)
+{
+    // Select the appropriate I2C Resource Manager
+    uint32_t i2c_sda = pinmap_peripheral(sda, PinMap_I2C_SDA);
+    uint32_t i2c_scl = pinmap_peripheral(scl, PinMap_I2C_SCL);
+    int ownerID = pinmap_merge(i2c_sda, i2c_scl);
+    _owner = detail::get_i2c_owner(ownerID);
+    CORE_UTIL_ASSERT(I2CError::None == _owner->init(sda, scl));
+}
+
+I2C::~I2C ()
+{
+    if (_owner) {
+        _owner->release();
+    }
+}
+
+void I2C::frequency(uint32_t hz)
+{
+    _hz = hz;
+}
+
+I2C::TransferAdder I2C::transfer_to(int address)
+{
+    TransferAdder t(this, address, _hz, false);
+    return t;
+}
+
+I2C::TransferAdder I2C::transfer_to_irqsafe(int address)
+{
+    TransferAdder t(this, address, _hz, true);
+    return t;
+}
+
+I2CError I2C::post_transaction(I2CTransaction *t)
+{
+    if (!_owner) {
+        return I2CError::InvalidMaster;
+    }
+    return _owner->post_transaction(t);
+}
+
+detail::I2CSegment * I2C::new_segment(bool irqsafe)
+{
+    detail::I2CSegment * newseg = nullptr;
+    if (irqsafe) {
+        if (!SegmentPool) {
+            return nullptr;
+        }
+        void * space = SegmentPool->alloc();
+        if (!space) {
+            return nullptr;
+        }
+        newseg = new(space) detail::I2CSegment();
+    } else {
+        newseg = new detail::I2CSegment();
+    }
+    return newseg;
+}
+
+I2CTransaction * I2C::new_transaction(uint16_t address, uint32_t hz, bool irqsafe, I2C *issuer)
+{
+    I2CTransaction * t;
+    if (irqsafe) {
+        if (!TransactionPool) {
+            return nullptr;
+        }
+        void *space = TransactionPool->alloc();
+        if (!space) {
+            return nullptr;
+        }
+        t = new(space) I2CTransaction(address, hz, irqsafe, issuer);
+    } else {
+        t = new I2CTransaction(address, hz, irqsafe, issuer);
+    }
+    return t;
+}
+
+void I2C::free(detail::I2CSegment *s, bool irqsafe)
+{
+    if (irqsafe) {
+        s->~I2CSegment();
+        SegmentPool->free(s);
+    } else {
+        delete s;
+    }
+}
+
+void I2C::free(I2CTransaction *t)
+{
+    if (t->is_irqsafe()) {
+        t->~I2CTransaction();
+        TransactionPool->free(t);
+    } else {
+        delete t;
+    }
+}
+
+I2C::TransferAdder::TransferAdder(I2C *i2c, int address, uint32_t hz, bool irqsafe) :
+    _i2c(i2c), _posted(false), _irqsafe(irqsafe), _rc(I2CError::None)
+{
+    CORE_UTIL_ASSERT(!irqsafe || (irqsafe && i2c->TransactionPool && i2c->SegmentPool));
+    if (irqsafe && (!i2c->TransactionPool || !i2c->SegmentPool)) {
+        _rc = I2CError::MissingPoolAllocator;
+        return;
+    }
+    _xact = i2c->new_transaction(address, hz, irqsafe, i2c);
+    CORE_UTIL_ASSERT(_xact != nullptr);
+    if (!_xact) {
+        _rc = I2CError::NullTransaction;
+        return;
+    }
+}
+
+I2CError I2C::TransferAdder::apply()
+{
+    if (_rc != I2CError::None) {
+        return _rc;
+    }
+    if (!_posted) {
+        _rc = _i2c->post_transaction(_xact);
+        if (_rc == I2CError::None) {
+            _posted = true;
+        }
+    }
+    return I2CError::None;
+}
+
+I2C::TransferAdder & I2C::TransferAdder::on(uint32_t event, const event_callback_t & cb)
+{
+    if (_rc == I2CError::None) {
+        _xact->add_event(event, cb);
+    }
+    return *this;
+}
+
+I2C::TransferAdder & I2C::TransferAdder::on(uint32_t event, event_callback_t && cb)
+{
+    if (_rc == I2CError::None) {
+        _xact->add_event(event, cb);
+    }
+    return *this;
+}
+
+I2C::TransferAdder & I2C::TransferAdder::frequency(uint32_t hz)
+{
+    if (_rc == I2CError::None) {
+        _xact->frequency(hz);
+    }
+    return *this;
+}
+
+I2C::TransferAdder::~TransferAdder()
+{
+    apply();
+    // If the transaction has not been posted, the TransferAdder still owns it, so it must be freed.
+    if (!_posted) {
+        delete _xact;
+    }
+}
+
+detail::I2CSegment * I2C::TransferAdder::new_segment(detail::I2CDirection d)
+{
+    detail::I2CSegment * s = nullptr;
+    if (_rc == I2CError::None && _xact) {
+        // Prevent successive segments in the same direction since these are not supported by the HAL.
+        CORE_UTIL_ASSERT_MSG(_xact->get_current()->get_dir() != d,
+                             "I2C transactions must alternate tx() and rx() calls");
+        if (_xact->get_current()->get_dir() == d) {
+            _rc = I2CError::ScatterGatherNotSupported;
+            return nullptr;
+        }
+        s = _xact->new_segment();
+        CORE_UTIL_ASSERT(s != nullptr);
+        if (!s) {
+            _rc = I2CError::NullSegment;
+        } else {
+            s->set_dir(d);
+        }
+    }
+    return s;
+}
+
+I2C::TransferAdder & I2C::TransferAdder::tx(void *buf, size_t len)
+{
+    detail::I2CSegment * s = new_segment(detail::I2CDirection::Transmit);
+    if (s) {
+        s->set(buf,len);
+    }
+    return *this;
+}
+
+I2C::TransferAdder & I2C::TransferAdder::tx(const Buffer & buf)
+{
+    detail::I2CSegment * s = new_segment(detail::I2CDirection::Transmit);
+    if (s) {
+        s->set(buf);
+    }
+    return *this;
+}
+
+I2C::TransferAdder & I2C::TransferAdder::tx_ephemeral(void *buf, size_t len)
+{
+    if(len > mbed::drivers::v2::EphemeralBuffer::ephemeralSize) {
+        _rc = I2CError::BufferSize;
+    } else {
+        detail::I2CSegment * s = new_segment(detail::I2CDirection::Transmit);
+        if (s) {
+            s->set_ephemeral(buf,len);
+        }
+    }
+    return *this;
+}
+
+I2C::TransferAdder & I2C::TransferAdder::rx(void *buf, size_t len)
+{
+    detail::I2CSegment * s = new_segment(detail::I2CDirection::Receive);
+    if (s) {
+        s->set(buf,len);
+    }
+    return *this;
+}
+
+I2C::TransferAdder & I2C::TransferAdder::rx(const Buffer & buf)
+{
+    detail::I2CSegment * s = new_segment(detail::I2CDirection::Receive);
+    if (s) {
+        s->set(buf);
+    }
+    return *this;
+}
+
+I2C::TransferAdder & I2C::TransferAdder::rx(size_t len)
+{
+
+    if(len > mbed::drivers::v2::EphemeralBuffer::ephemeralSize) {
+        _rc = I2CError::BufferSize;
+    } else {
+        detail::I2CSegment * s = new_segment(detail::I2CDirection::Receive);
+        if (s) {
+            s->set_ephemeral(nullptr,len);
+        }
+    }
+    return *this;
+}
+} // namespace v2
+} // namespace drivers
+} // namespace mbed
+
+#endif

--- a/source/v2/I2CDetail.cpp
+++ b/source/v2/I2CDetail.cpp
@@ -1,0 +1,336 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed-drivers/platform.h"
+
+#if DEVICE_I2C && DEVICE_I2C_ASYNCH
+
+#include "mbed-drivers/v2/I2C.hpp"
+#include "core-util/CriticalSectionLock.h"
+#include "core-util/atomic_ops.h"
+#include "core-util/assert.h"
+#include "minar/minar.h"
+
+namespace mbed {
+namespace drivers {
+namespace v2 {
+namespace detail {
+
+I2CError I2CResourceManager::post_transaction(I2CTransaction *t)
+{
+    CORE_UTIL_ASSERT(t != nullptr);
+    if (!t) {
+        return I2CError::NullTransaction;
+    }
+    I2CError rc = validate_transaction(t);
+    if (rc != I2CError::None) {
+        return rc;
+    }
+
+    // This can't be lock free because of the need to call append() on _TransactionQueue.
+    mbed::util::CriticalSectionLock lock;
+    I2CTransaction * tx = _TransactionQueue;
+
+    if (tx) {
+        tx->append(t);
+    } else {
+        _TransactionQueue = t;
+        return start_transaction();
+    }
+    return I2CError::None;
+}
+
+void I2CResourceManager::process_event(uint32_t event)
+{
+    I2CTransaction * t;
+    CORE_UTIL_ASSERT(_TransactionQueue != nullptr);
+    if (!_TransactionQueue) {
+        return;
+    }
+    // Get the current item in the transaction queue
+    t = _TransactionQueue;
+    if (!t) {
+        return;
+    }
+    // If the event is 0, no further action is required
+    if (!event) {
+        return;
+    }
+    // Fire the irqcallback for the segment
+    t->call_irq_cb(event);
+    {
+        // This isn't done with atomics due to the side-effects.
+        mbed::util::CriticalSectionLock lock;
+
+        // If there is another segment to process, advance the segment pointer
+        // Record whether there was another segment
+        bool TransactionDone = !t->advance_segment();
+        // If there was an event that is not a complete event
+        // or there was a complete event and the next segment is nullptr
+        if ((event & I2C_EVENT_ALL & ~I2C_EVENT_TRANSFER_COMPLETE) ||
+                ((event & I2C_EVENT_TRANSFER_COMPLETE) && TransactionDone)) {
+            // fire the handler
+            minar::Scheduler::postCallback(
+                I2C_event_callback_t(this, &I2CResourceManager::handle_event).bind(t,event)
+            );
+            // Advance to the next transaction
+            _TransactionQueue = t->get_next();
+            if (_TransactionQueue) {
+                // Initiate the next transaction
+                start_transaction();
+            } else {
+            }
+        } else if (!TransactionDone) {
+            start_segment();
+        }
+    }
+}
+
+void I2CResourceManager::handle_event(I2CTransaction *t, uint32_t event)
+{
+    t->process_event(event);
+    // This happens after the callbacks have all been called
+    t->get_issuer()->free(t);
+}
+
+I2CResourceManager::I2CResourceManager() : _TransactionQueue(nullptr) {}
+
+I2CResourceManager::~I2CResourceManager()
+{
+    mbed::util::CriticalSectionLock lock;
+    while (_TransactionQueue) {
+        I2CTransaction * tx = (_TransactionQueue);
+        _TransactionQueue = tx->get_next();
+        tx->get_issuer()->free(tx);
+    }
+}
+
+class HWI2CResourceManager : public I2CResourceManager
+{
+public:
+    HWI2CResourceManager(const size_t id, void(*handler)(void)):
+        _scl(NC),
+        _sda(NC),
+        _i2c(),
+        _id(id),
+        _references(0),
+        _handler(handler)
+    {}
+
+    virtual I2CError init(PinName sda, PinName scl)
+    {
+        /*
+         * Calling init during a transaction could cause communication artifacts, so only a single call to init is
+         * permitted unless all references are dropped
+         */
+        if (_references == 0 && (_scl != NC || _sda != NC)) {
+            return I2CError::DeinitInProgress;
+        }
+        if (mbed::util::atomic_incr<std::uint32_t>(const_cast<std::uint32_t *>(&_references), 1) == 1) {
+            // The init function also set the frequency to 100000
+            i2c_init(&_i2c, sda, scl);
+            /* Set _scl and _sda after i2c_init is done so that an interrupting call to init will fail because _scl and
+             * _sda are NC.
+             */
+            _scl = scl;
+            _sda = sda;
+
+        } else {
+            CORE_UTIL_ASSERT_MSG(_scl == scl && _sda == sda, "Each I2C peripheral may only be used on one set of pins");
+            // Only support an I2C master on a single pair of pins
+            if (_scl != scl || _sda != sda) {
+                return I2CError::PinMismatch;
+            }
+        }
+        return I2CError::None;
+    }
+
+    virtual void release()
+    {
+        if (mbed::util::atomic_decr<std::uint32_t>(const_cast<std::uint32_t *>(&_references), 1) == 0) {
+            // i2c_free(&_i2c); // mbed-hal#71
+            _sda = NC;
+            _scl = NC;
+        }
+    }
+
+    virtual I2CError start_segment ()
+    {
+        I2CTransaction * t = _TransactionQueue;
+        CORE_UTIL_ASSERT(t != nullptr);
+        if (!t) {
+            return I2CError::NullTransaction;
+        }
+        I2CSegment * s = t->get_current();
+        CORE_UTIL_ASSERT(s != nullptr);
+        if (!s) {
+            return I2CError::NullSegment;
+        }
+        bool stop = (s->get_next() == nullptr);
+        if (s->get_dir() == I2CDirection::Transmit) {
+            i2c_transfer_asynch(&_i2c, s->get_buf(), s->get_len(), nullptr, 0, t->address(),
+                                stop, (uint32_t)_handler, I2C_EVENT_ALL, DMA_USAGE_NEVER);
+        } else {
+            i2c_transfer_asynch(&_i2c, nullptr, 0, s->get_buf(), s->get_len(), t->address(),
+                                stop, (uint32_t)_handler, I2C_EVENT_ALL, DMA_USAGE_NEVER);
+        }
+        return I2CError::None;
+    }
+
+    virtual I2CError start_transaction()
+    {
+        if (i2c_active(&_i2c)) {
+            return I2CError::Busy; // transaction ongoing
+        }
+        mbed::util::CriticalSectionLock lock;
+        I2CTransaction * t = _TransactionQueue;
+        CORE_UTIL_ASSERT(t != nullptr);
+        if (!t) {
+            return I2CError::NullTransaction;
+        }
+        i2c_frequency(&_i2c, t->frequency());
+        t->reset_current();
+        // Special case for pings:
+        if (t->get_current() == nullptr) {
+            i2c_transfer_asynch(&_i2c, nullptr, 0, nullptr, 0, t->address(),
+                                true, (uint32_t)_handler, I2C_EVENT_ALL, DMA_USAGE_NEVER);
+            return I2CError::None;
+        }
+        return start_segment();
+    }
+
+    virtual I2CError validate_transaction(I2CTransaction *t) const
+    {
+        uint16_t address = t->address();
+        if (address >= 1<<10) {
+            return I2CError::InvalidAddress;
+        }
+        return I2CError::None;
+    }
+
+    void irq_handler()
+    {
+        uint32_t event = i2c_irq_handler_asynch(&_i2c);
+        // No further action is required if the event is 0.
+        if (event) {
+            process_event(event);
+        }
+    }
+
+protected:
+    PinName _scl;
+    PinName _sda;
+    i2c_t _i2c;
+    const size_t _id;
+    volatile uint32_t _references;
+    void (*const _handler)(void);
+};
+
+template <size_t N>
+struct HWI2CResourceManagers : public HWI2CResourceManagers<N-1> {
+public:
+    HWI2CResourceManagers() : rm(N, irq_handler_asynch) {}
+
+private:
+    HWI2CResourceManager rm;
+
+    static void irq_handler_asynch(void)
+    {
+        HWI2CResourceManager *rm = static_cast<HWI2CResourceManager *>(get_i2c_owner(N));
+        rm->irq_handler();
+    }
+
+public:
+    I2CResourceManager * get_rm(size_t I)
+    {
+        CORE_UTIL_ASSERT(I <= N);
+        if (I > N) {
+            return nullptr;
+        } else if (I == N) {
+            return &rm;
+        } else {
+            return HWI2CResourceManagers<N-1>::get_rm(I);
+        }
+    }
+};
+
+template <>
+struct HWI2CResourceManagers<0> {
+public:
+    HWI2CResourceManagers() : rm(0, irq_handler_asynch) {}
+
+private:
+    HWI2CResourceManager rm;
+
+    static void irq_handler_asynch(void)
+    {
+        HWI2CResourceManager *rm = static_cast<HWI2CResourceManager *>(get_i2c_owner(0));
+        rm->irq_handler();
+    }
+
+public:
+    I2CResourceManager * get_rm(size_t I)
+    {
+        CORE_UTIL_ASSERT(I == 0);
+        if (I) {
+            return nullptr;
+        } else {
+            return &rm;
+        }
+    }
+};
+
+I2CResourceManager * get_i2c_owner(int I)
+{
+    // Trap a failed pinmap_merge()
+    CORE_UTIL_ASSERT_MSG(I >=0, "The scl, sda combination must exist in the peripheral pin map");
+    if (I < 0) {
+        return nullptr;
+    }
+    // Instantiate the HWI2CResourceManager
+    static struct HWI2CResourceManagers<MODULES_SIZE_I2C-1> HWManagers;
+    if (I < MODULES_SIZE_I2C) {
+        return HWManagers.get_rm(I);
+    } else {
+        CORE_UTIL_ASSERT(false);
+        return nullptr;
+    }
+}
+
+I2CEventHandler::I2CEventHandler():_cb(), _eventmask(0) {}
+
+void I2CEventHandler::call(I2CTransaction *t, uint32_t event)
+{
+    _cb(t,event);
+}
+
+void I2CEventHandler::set(const I2C_event_callback_t &cb, uint32_t event)
+{
+    _cb = cb;
+    _eventmask = event;
+}
+
+I2CEventHandler::operator bool() const
+{
+    return _eventmask && _cb;
+}
+
+} // namespace detail
+} // namespace v2
+} // drivers
+} // namespace mbed
+#endif // DEVICE_I2C && DEVICE_I2C_ASYNCH


### PR DESCRIPTION
Much in the same vein as https://github.com/ARMmbed/mbed-drivers/pull/93, add a fluent API to I2C

cc @0xc0170 @bogdanm @salkinium @hugovincent @autopulated 