### PR TITLE
Updated readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,9 @@
 # mbed-drivers
 
 This module is one of the main 'entry points' into mbed OS. It contains the definition and implementation of the
-high level (user facing) API for the MCU peripherals, as well as the implementation of the `main` function
-(check [the MINAR documentation](https://github.com/ARMmbed/minar) for more details about the usage of `main`
-in mbed OS).
+high level (user facing) API for the MCU peripherals, as well as the implementation of the `main` function.
 
 Because of this, you'll always want to make `mbed-drivers` a dependency of your mbed OS application. Check
-[our user guide](https://docs.mbed.com/docs/getting-started-mbed-os/) for more details about `mbed-drivers` and
-mbed OS in general.
+[our getting started guide](https://docs.mbed.com/docs/getting-started-mbed-os/) for more details about `mbed-drivers`
+and mbed OS in general.
 

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,11 @@
+
 # mbed-drivers
 
 This module is one of the main 'entry points' into mbed OS. It contains the definition and implementation of the
-high level (user facing) API for the MCU peripherals, as well as the implementation of the `main` function.
+high level (user facing) API for the MCU peripherals, as well as the implementation of the `main` function
+(mbed OS application use `app_start` instead of `main`, check ["Writing applications for mbed OS"](https://docs.mbed.com/docs/getting-started-mbed-os/en/latest/Full_Guide/app_on_yotta/#writing-applications-for-mbed-os)
+for more details).
 
 Because of this, you'll always want to make `mbed-drivers` a dependency of your mbed OS application. Check
-[our getting started guide](https://docs.mbed.com/docs/getting-started-mbed-os/) for more details about `mbed-drivers`
+[our "Getting started" guide](https://docs.mbed.com/docs/getting-started-mbed-os/) for more details about `mbed-drivers`
 and mbed OS in general.
-

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 
 This module is one of the main 'entry points' into mbed OS. It contains the definition and implementation of the
 high level (user facing) API for the MCU peripherals, as well as the implementation of the `main` function
-(mbed OS application use `app_start` instead of `main`, check ["Writing applications for mbed OS"](https://docs.mbed.com/docs/getting-started-mbed-os/en/latest/Full_Guide/app_on_yotta/#writing-applications-for-mbed-os)
+(mbed OS applications use `app_start` instead of `main`; check ["Writing applications for mbed OS"](https://docs.mbed.com/docs/getting-started-mbed-os/en/latest/Full_Guide/app_on_yotta/#writing-applications-for-mbed-os)
 for more details).
 
 Because of this, you'll always want to make `mbed-drivers` a dependency of your mbed OS application. Check

--- a/readme.md
+++ b/readme.md
@@ -1,25 +1,11 @@
-## Building with yotta
+# mbed-drivers
 
-mbed OS is built using yotta. So first, install [yotta](http://github.com/ARMmbed/yotta), then:
+This module is one of the main 'entry points' into mbed OS. It contains the definition and implementation of the
+high level (user facing) API for the MCU peripherals, as well as the implementation of the `main` function
+(check [the MINAR documentation](https://github.com/ARMmbed/minar) for more details about the usage of `main`
+in mbed OS).
 
-```bash
-# get the mbed OS drivers source code:
-git clone git@github.com:ARMmbed/mbed-drivers.git
-cd mbed-drivers
-
-# build for the frdm-k64f-gcc target:
-yotta target frdm-k64f-gcc
-
-# build
-yotta build
-...
-
-# fire up the debugger with the blinky test loaded
-yotta debug test/mbed-test-blinky
-...
-> mon reset
-> load
-> continue
-
-```
+Because of this, you'll always want to make `mbed-drivers` a dependency of your mbed OS application. Check
+[our user guide](https://docs.mbed.com/docs/getting-started-mbed-os/) for more details about `mbed-drivers` and
+mbed OS in general.
 


### PR DESCRIPTION
The old readme didn't give any pointer about the purpose of
mbed-drivers, showing instead some build instructions that can apply
equally well to any other repository. The new readme mentions some of
the important changes in mbed OS (no `main` function for apps) and
directs the user to the mbed OS starting guide.