### PR TITLE
Fix for #ksdk-issue-8 - spi busy for asynch

### DIFF
--- a/mbed-drivers/SPI.h
+++ b/mbed-drivers/SPI.h
@@ -241,6 +241,7 @@ protected:
     int _mode;
     spi_bitorder_t _order;
     int _hz;
+    bool _busy;
 };
 
 } // namespace mbed

--- a/source/SPI.cpp
+++ b/source/SPI.cpp
@@ -162,6 +162,7 @@ void SPI::dequeue_transaction()
     {
         CriticalSectionLock lock;
         dequeued = _transaction_buffer.pop(t);
+        _busy = dequeued;
     }
 
     if (dequeued) {
@@ -183,15 +184,7 @@ void SPI::irq_handler_asynch(void)
     }
 #if TRANSACTION_QUEUE_SIZE_SPI
     if (event & (SPI_EVENT_ALL | SPI_EVENT_INTERNAL_TRANSFER_COMPLETE)) {
-        bool dequeue;
-        {
-            CriticalSectionLock lock;
-            dequeue = !spi_active(&_spi);
-            _busy = dequeue;
-        }
-        if (dequeue) {
-            dequeue_transaction();
-        }
+        dequeue_transaction();
     }
 #endif
 }


### PR DESCRIPTION
Additions:
- busy flag - per object to reflect that transfer is ongoing (started, about to start) - the flag is not static - because for example SPI_0 does not block SPI_1 module.
- critical locks for queue actions -  we have currently one queue for all spi modules - there can be multiple reader/writers

@bogdanm @bremoran 