### PR TITLE
Add redefinition of OPEN_MAX through yotta

### DIFF
--- a/source/retarget.cpp
+++ b/source/retarget.cpp
@@ -50,6 +50,11 @@
 #   define PREFIX(x)    x
 #endif
 
+#ifdef YOTTA_CFG_MBED_MAX_FILEHANDLES
+#   undef OPEN_MAX
+#   define OPEN_MAX YOTTA_CFG_MBED_MAX_FILEHANDLES
+#endif
+
 #ifndef pid_t
  typedef int pid_t;
 #endif

--- a/source/retarget.cpp
+++ b/source/retarget.cpp
@@ -29,7 +29,6 @@
 #if defined(__ARMCC_VERSION)
 #   include <rt_sys.h>
 #   define PREFIX(x)    _sys##x
-#   define OPEN_MAX     _SYS_OPEN
 #   ifdef __MICROLIB
 #       pragma import(__use_full_stdio)
 #   endif
@@ -37,7 +36,6 @@
 #elif defined(__ICCARM__)
 #   include <yfuns.h>
 #   define PREFIX(x)        _##x
-#   define OPEN_MAX         16
 
 #   define STDIN_FILENO     0
 #   define STDOUT_FILENO    1
@@ -50,9 +48,8 @@
 #   define PREFIX(x)    x
 #endif
 
-#ifdef YOTTA_CFG_MBED_MAX_FILEHANDLES
-#   undef OPEN_MAX
-#   define OPEN_MAX YOTTA_CFG_MBED_MAX_FILEHANDLES
+#ifndef YOTTA_CFG_MBED_MAX_FILEHANDLES
+#   define YOTTA_CFG_MBED_MAX_FILEHANDLES 16
 #endif
 
 #ifndef pid_t
@@ -81,7 +78,7 @@ extern const char __stderr_name[] = "/stderr";
  * put it in a filehandles array and return the index into that array
  * (or rather index+3, as filehandles 0-2 are stdin/out/err).
  */
-static FileHandle *filehandles[OPEN_MAX];
+static FileHandle *filehandles[YOTTA_CFG_MBED_MAX_FILEHANDLES];
 
 FileHandle::~FileHandle() {
     /* Remove all open filehandles for this */


### PR DESCRIPTION
Add preprocessor directives to redefine the value of `OPEN_MAX` to `YOTTA_CFG_MBED_MAX_FILEHANDLES`, a macro defined through yotta. This enables users to manually set the size of the `filehandles` array through a yotta config file and get some memory savings.

@bogdanm @0xc0170 