### PR TITLE
Add support for code coverage

### DIFF
--- a/mbed-drivers/test_env.h
+++ b/mbed-drivers/test_env.h
@@ -44,6 +44,10 @@ void notify_timeout(int timeout);
 void notify_test_id(const char *test_id);
 void notify_test_description(const char *description);
 
+// Code Coverage API
+void notify_coverage_start(const char *path);
+void notify_coverage_end();
+
 // Host test auto-detection API
 #define MBED_HOSTTEST_START(TESTID)      notify_test_id(TESTID); notify_start()
 #define MBED_HOSTTEST_SELECT(NAME)       notify_host_test_name(#NAME)

--- a/source/test_env.cpp
+++ b/source/test_env.cpp
@@ -23,6 +23,12 @@ const char* TEST_ENV_FAILURE = "failure";
 const char* TEST_ENV_MEASURE = "measure";
 const char* TEST_ENV_END = "end";
 
+/* prototype */
+extern "C"
+void gcov_exit(void);
+#ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
+bool coverage_report = false;
+#endif
 
 static void led_blink(PinName led, float delay)
 {
@@ -59,6 +65,11 @@ void notify_performance_coefficient(const char* measurement_name, const double v
 void notify_completion(bool success)
 {
     printf("{{%s}}" NL "{{%s}}" NL, success ? TEST_ENV_SUCCESS : TEST_ENV_FAILURE, TEST_ENV_END);
+#ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
+    coverage_report = true;
+    gcov_exit();
+    coverage_report = false;
+#endif
     led_blink(LED1, success ? 1.0 : 0.1);
 }
 
@@ -95,6 +106,14 @@ void notify_test_description(const char *description) {
     }
 }
 
+#ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
+void notify_coverage_start(const char *path) {
+    printf("{{coverage_start;%s}}" NL, path);
+}
+void notify_coverage_end() {
+    printf("{{coverage_end}}" NL);
+}
+#endif
 
 // -DMBED_BUILD_TIMESTAMP=1406208182.13
 unsigned int testenv_randseed()

--- a/source/test_env.cpp
+++ b/source/test_env.cpp
@@ -64,12 +64,13 @@ void notify_performance_coefficient(const char* measurement_name, const double v
 
 void notify_completion(bool success)
 {
-    printf("{{%s}}" NL "{{%s}}" NL, success ? TEST_ENV_SUCCESS : TEST_ENV_FAILURE, TEST_ENV_END);
+    printf("{{%s}}" NL, success ? TEST_ENV_SUCCESS : TEST_ENV_FAILURE);
 #ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
     coverage_report = true;
     gcov_exit();
     coverage_report = false;
 #endif
+    printf("{{%s}}" NL, TEST_ENV_END);
     led_blink(LED1, success ? 1.0 : 0.1);
 }
 


### PR DESCRIPTION
Add coverage start/end blocks
Add a flag variable that indicates whether a coverage dump is in progress
Override file handle 3 while code coverage is active to indicate coverage output
Override _write() on file handle 3 while code coverage is active to hex-encode all data. Note that gcov uses single-byte writes, so base64 encoding would require global state.
Override _open() while code coverage is active: dump file name in a coverage block header, and return file handle 3
Override _close(3) while code coverage is active: dump a coverage block footer