### PR TITLE
add variable arguemnt support to stream

### DIFF
--- a/mbed-drivers/Stream.h
+++ b/mbed-drivers/Stream.h
@@ -18,7 +18,7 @@
 
 #include "platform.h"
 #include "FileLike.h"
-#include "cstdarg"
+#include <cstdarg>
 
 namespace mbed {
 

--- a/mbed-drivers/Stream.h
+++ b/mbed-drivers/Stream.h
@@ -18,6 +18,7 @@
 
 #include "platform.h"
 #include "FileLike.h"
+#include "cstdarg"
 
 namespace mbed {
 
@@ -33,6 +34,8 @@ public:
     char *gets(char *s, int size);
     int printf(const char* format, ...);
     int scanf(const char* format, ...);
+    int vprintf(const char* format, std::va_list args);
+    int vscanf(const char* format, std::va_list args);
 
     operator std::FILE*() {return _file;}
 

--- a/source/Stream.cpp
+++ b/source/Stream.cpp
@@ -15,8 +15,6 @@
  */
 #include "mbed-drivers/Stream.h"
 
-#include <cstdarg>
-
 namespace mbed {
 
 Stream::Stream(const char *name) : FileLike(name), _file(NULL) {
@@ -106,6 +104,18 @@ int Stream::scanf(const char* format, ...) {
     fflush(_file);
     int r = vfscanf(_file, format, arg);
     va_end(arg);
+    return r;
+}
+
+int Stream::vprintf(const char* format, std::va_list args) {
+    fflush(_file);
+    int r = vfprintf(_file, format, args);
+    return r;
+}
+
+int Stream::vscanf(const char* format, std::va_list args) {
+    fflush(_file);
+    int r = vfscanf(_file, format, args);
     return r;
 }
 


### PR DESCRIPTION
Makes logging a little easier and more consistent in implementation. Also fewer local buffers.
```
void trace(const char* format, ...)
{
    va_list argp;
    va_start(argp, format);
    vprintf(format, argp);
    va_end(argp);
}
```