### PR TITLE
Disable app.h

### DIFF
--- a/mbed-drivers/app.h
+++ b/mbed-drivers/app.h
@@ -17,29 +17,7 @@
 #ifndef __MBED_CORE_MBED_APP_H__
 #define __MBED_CORE_MBED_APP_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif // #ifdef __cplusplus
-
-/** app_start is used to set up the user's application. It should not block.
- *
- * Use this function to schedule the first code that your app will execute, and
- * perform non-blocking initialisation.
- *
- * @code
- * using namespace mbed::minar;
- * void app_start(int argc, char *argv[]){
- *     Scheduler::postCallback(&doSomething);
- *     Scheduler::postCallback(&doSomethingElse).delay(milliseconds(100)).period(milliseconds(200));
- * }
- * @endcode
- */
-
-void app_start(int argc, char *argv[]);
-
-#ifdef __cplusplus
-} // extern "C"
-#endif // #ifdef __cplusplus
+#warning You don't need to include 'app.h' anymore. This header is obsolete and will be removed.
 
 #endif // ndef __MBED_CORE_MBED_APP_H__
 

--- a/mbed-drivers/mbed.h
+++ b/mbed-drivers/mbed.h
@@ -24,8 +24,6 @@
 #include <math.h>
 #include <time.h>
 
-// declare app_start:
-#include "app.h"
 // pull in definition of the mbed scheduler:
 #include "minar/minar.h"
 

--- a/source/retarget.cpp
+++ b/source/retarget.cpp
@@ -21,7 +21,6 @@
 #include "compiler-polyfill/attributes.h"
 #include "cmsis.h"
 #include <errno.h>
-#include "mbed-drivers/app.h"
 #include "minar/minar.h"
 #include "mbed-hal/init_api.h"
 #include "core_generic.h"
@@ -490,6 +489,7 @@ extern "C" void __iar_argc_argv() {
 #endif
 
 // the user should set up their application in app_start
+extern void app_start(int, char**);
 extern "C" int main(void) {
     minar::Scheduler::postCallback(
         mbed::util::FunctionPointer2<void, int, char**>(&app_start).bind(0, NULL)


### PR DESCRIPTION
As decribed in #136 and #118, app.h is redundant and problematic.
This commit replaces the previous code in app.h with a deprecation
warning, instead of removing it completely, to keep compatibility
with code that includes "app.h" explicitly.

Tested by compiling mbed-drivers, minar and core-util with
mbed-k64f-gcc and mbed-k64f-armcc.