### PR TITLE
Changed console initialization

### DIFF
--- a/source/retarget.cpp
+++ b/source/retarget.cpp
@@ -112,6 +112,7 @@ static void init_serial() {
     if (stdio_uart_inited) return;
     serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
     serial_baud(&stdio_uart, STDIO_DEFAULT_BAUD);
+    stdio_uart_inited = 1;
 #endif
 }
 

--- a/source/retarget.cpp
+++ b/source/retarget.cpp
@@ -24,6 +24,7 @@
 #include "mbed-drivers/app.h"
 #include "minar/minar.h"
 #include "mbed-hal/init_api.h"
+#include "mbed-hal/serial_api.h"
 #include "core_generic.h"
 
 #if defined(__ARMCC_VERSION)
@@ -102,8 +103,8 @@ FileHandle::~FileHandle() {
 }
 
 #if DEVICE_SERIAL
-extern int stdio_uart_inited;
-extern serial_t stdio_uart;
+static int stdio_uart_inited;
+static serial_t stdio_uart;
 #endif
 
 static void init_serial() {


### PR DESCRIPTION
All the initialization related to console operations (stdout/stderr/stdin)
now happens in retarget.cpp. The relevant parts will be removed from the
target specific code in subsequent commits.