### PR TITLE
Retarget - main - invoke serial init

### DIFF
--- a/source/retarget.cpp
+++ b/source/retarget.cpp
@@ -493,6 +493,8 @@ extern "C" void __iar_argc_argv() {
 // the user should set up their application in app_start
 extern void app_start(int, char**);
 extern "C" int main(void) {
+    // init serial if it has not been invoked prior main
+    init_serial();
     minar::Scheduler::postCallback(
         mbed::util::FunctionPointer2<void, int, char**>(&app_start).bind(0, NULL)
     );


### PR DESCRIPTION
Some toolchains might not call open() for stdio handles prior main, which breaks usage:
```
void app_start(int, char**)
{
    Serial pc(tx, rx);
	pc.baud(115200);
	printf("sss \n"); //open stdio might happen here
}
```
An example above was not working for our gcc targets.

A note: YOTTA_CFG_MBED_OS_STDIO_DEFAULT_BAUD in this case is the one which is set, no matter what SerialBase ctor sets (if Serial() object (for USBTX,USBRX) is in a global scope, sets baudrate within ctor to different value than YOTTA_CFG_MBED_OS_STDIO_DEFAULT_BAUD), still get overwritten by YOTTA_CFG_MBED_OS_STDIO_DEFAULT_BAUD. Just stating this for a future reference

@bogdanm @pan- 