### PR TITLE
Retarget - stdio serial lazy initialization

### DIFF
--- a/mbed-drivers/Serial.h
+++ b/mbed-drivers/Serial.h
@@ -67,6 +67,12 @@ protected:
     virtual int _putc(int c);
 };
 
+/** Get the stdio Serial object, which is lazy instantiated.
+ *
+ *  @returns stdio object 
+ */
+Serial& get_stdio_serial();
+
 } // namespace mbed
 
 #endif

--- a/readme.md
+++ b/readme.md
@@ -9,3 +9,14 @@ for more details).
 Because of this, you'll always want to make `mbed-drivers` a dependency of your mbed OS application. Check
 [our "Getting started" guide](https://docs.mbed.com/docs/getting-started-mbed-os/) for more details about `mbed-drivers`
 and mbed OS in general.
+
+### STDIO retartgeting
+
+The mbed-drivers defines retargeting of stdin, stdout and stderr to UART. The default baudrate for STDIO UART peripheral is set via ```YOTTA_CFG_MBED_OS_STDIO_DEFAULT_BAUD```. If this yotta config is not defined, the default value is 115200.
+
+To change STDIO serial settings in the runtime, retrieve the Serial STDIO object ```get_stdio_serial()```.
+
+```
+Serial& pc = get_stdio_serial();
+pc.baud(9600);
+```

--- a/test/serial_interrupt/main.cpp
+++ b/test/serial_interrupt/main.cpp
@@ -20,7 +20,7 @@
 DigitalOut led1(LED1);
 DigitalOut led2(LED2);
 
-Serial computer(USBTX, USBRX);
+Serial& computer = get_stdio_serial();
 
 // This function is called when a character goes into the TX buffer.
 void txCallback() {
@@ -38,7 +38,6 @@ void app_start(int, char*[]) {
     MBED_HOSTTEST_SELECT(echo);
     MBED_HOSTTEST_DESCRIPTION(serial interrupt test);
     MBED_HOSTTEST_START("MBED_14");
-    computer.baud(115200);
     computer.attach(&txCallback, Serial::TxIrq);
     computer.attach(&rxCallback, Serial::RxIrq);
 }

--- a/test/serial_interrupt/main.cpp
+++ b/test/serial_interrupt/main.cpp
@@ -38,6 +38,7 @@ void app_start(int, char*[]) {
     MBED_HOSTTEST_SELECT(echo);
     MBED_HOSTTEST_DESCRIPTION(serial interrupt test);
     MBED_HOSTTEST_START("MBED_14");
+    computer.baud(115200);
     computer.attach(&txCallback, Serial::TxIrq);
     computer.attach(&rxCallback, Serial::RxIrq);
 }


### PR DESCRIPTION
We provide mbed::get_serial_stdio() to get a reference for stdio Serial
object. We should discourage to use Serial pc(USBTX, USBRX)

We should clean our tests/examples, to use this new function for stdio Serial operations like baud(), format() or any other.

Should fix #140

@marcuschangarm @bogdanm @pan- @bremoran 