### PR TITLE
PwmOut.h: Added destructor and call to pwmout_free in HAL.

### DIFF
--- a/mbed-drivers/PwmOut.h
+++ b/mbed-drivers/PwmOut.h
@@ -62,6 +62,12 @@ public:
         pwmout_init(&_pwm, pin);
     }
 
+    /** Free PwmOut and related resources
+     */
+    ~PwmOut() {
+        pwmout_free(&_pwm);
+    }
+
     /** Set the ouput duty-cycle, specified as a percentage (float)
      *
      *  @param value A floating-point value representing the output duty-cycle,


### PR DESCRIPTION
Destructor is necessary to achieve low power on the Wearable Reference Design.