### PR TITLE
Add yotta config defaults for SPI transaction queue size.

### DIFF
--- a/mbed-drivers/SPI.h
+++ b/mbed-drivers/SPI.h
@@ -29,6 +29,15 @@
 #include "CircularBuffer.h"
 #include "core-util/FunctionPointer.h"
 #include "Transaction.h"
+
+#ifndef YOTTA_CFG_MBED_DRIVERS_SPI_TRANSACTION_QUEUE
+#   define YOTTA_CFG_MBED_DRIVERS_SPI_TRANSACTION_QUEUE 16
+#endif
+// backwards compatible guard for definition in `mbed-hal-<chip>/target_config.h`
+#ifndef TRANSACTION_QUEUE_SIZE_SPI
+#   define TRANSACTION_QUEUE_SIZE_SPI     YOTTA_CFG_MBED_DRIVERS_SPI_TRANSACTION_QUEUE
+#endif
+
 #endif
 
 namespace mbed {


### PR DESCRIPTION
Backwards compatible with `mbed-hal-<chip>/target_config.h`.

@bogdanm @bremoran @0xc0170 @mjs-arm 