### PR TITLE
Fix gcov code coverage generation

### DIFF
--- a/source/test_env.cpp
+++ b/source/test_env.cpp
@@ -24,9 +24,8 @@ const char* TEST_ENV_MEASURE = "measure";
 const char* TEST_ENV_END = "end";
 
 /* prototype */
-extern "C"
-void gcov_exit(void);
 #ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
+extern "C" void __gcov_flush();
 bool coverage_report = false;
 #endif
 
@@ -67,7 +66,7 @@ void notify_completion(bool success)
     printf("{{%s}}" NL, success ? TEST_ENV_SUCCESS : TEST_ENV_FAILURE);
 #ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
     coverage_report = true;
-    gcov_exit();
+    __gcov_flush();
     coverage_report = false;
 #endif
     printf("{{%s}}" NL, TEST_ENV_END);


### PR DESCRIPTION
When mbed-drivers moved to lazy init of stdio, it introduced a fopen call. This fopen happened to use filehandle 3 for a serial port. Since gcov used filehandle 3, this caused contention with serial.

To fix this, several actions were required:
* Change gcov's file handle to something outside the range of the filehandles we typically allocate
* Trap calls to _read, _write, _lseek, and _fstat on the gcov file handle
* Add explicit checks for the gcov file handle in _write and _close
* Switch from using gcov_exit to __gcov_flush

cc @0xc0170 @PrzemekWirkus @bogdanm 