### PR TITLE
[devel_transport_update] Devel transport updates - test_env and retarget issues.

### DIFF
--- a/mbed-drivers/test_env.h
+++ b/mbed-drivers/test_env.h
@@ -14,7 +14,88 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __MBED_DRIVERS_TEST_ENV_H__
-#define __MBED_DRIVERS_TEST_ENV_H__
-#warning mbed-drivers/test_env.h is deprecated.  Please use greentea-client/test_env.h instead.
-#endif // __MBED_DRIVERS_TEST_ENV_H__
+#ifndef TEST_ENV_H_
+#define TEST_ENV_H_
+
+#include <stdio.h>
+#include "mbed.h"
+
+#define NL "\n"
+#define RCNL "\r\n"
+
+// Const strings used in test_end
+extern const char* TEST_ENV_START;
+extern const char* TEST_ENV_SUCCESS;
+extern const char* TEST_ENV_FAILURE;
+extern const char* TEST_ENV_MEASURE;
+extern const char* TEST_ENV_END;
+
+// Test result related notification functions
+void notify_start();
+void notify_completion(bool success);
+bool notify_completion_str(bool success, char* buffer);
+void notify_performance_coefficient(const char* measurement_name, const int value);
+void notify_performance_coefficient(const char* measurement_name, const unsigned int value);
+void notify_performance_coefficient(const char* measurement_name, const double value);
+
+// Host test auto-detection API
+void notify_host_test_name(const char *host_test);
+void notify_timeout(int timeout);
+void notify_test_id(const char *test_id);
+void notify_test_description(const char *description);
+
+// Code Coverage API
+void notify_coverage_start(const char *path);
+void notify_coverage_end();
+
+// Host test auto-detection API
+#define MBED_HOSTTEST_START(TESTID)      notify_test_id(TESTID); notify_start()
+#define MBED_HOSTTEST_SELECT(NAME)       notify_host_test_name(#NAME)
+#define MBED_HOSTTEST_TIMEOUT(SECONDS)   notify_timeout(SECONDS)
+#define MBED_HOSTTEST_DESCRIPTION(DESC)  notify_test_description(#DESC)
+#define MBED_HOSTTEST_RESULT(RESULT)     notify_completion(RESULT)
+#define MBED_HOSTTEST_ASSERT(cond)       \
+    do {                                 \
+        if (!(cond)) {                   \
+            printf("HOSTTEST ASSERTION FAILED: '%s' in %s, line %d\r\n", #cond, __FILE__, __LINE__); \
+            notify_completion(false);    \
+        }                                \
+    } while(false)
+
+/**
+    Test auto-detection preamble example:
+    main() {
+        MBED_HOSTTEST_TIMEOUT(10);
+        MBED_HOSTTEST_SELECT( host_test );
+        MBED_HOSTTEST_DESCRIPTION(Hello World);
+        MBED_HOSTTEST_START("MBED_10");
+        // Proper 'host_test.py' should take over supervising of this test
+
+        // Test code
+        bool result = ...;
+
+        MBED_HOSTTEST_RESULT(result);
+    }
+*/
+
+
+// Test functionality useful during testing
+unsigned int testenv_randseed();
+
+// Macros, unit test like to provide basic comparisons
+#define TESTENV_STRCMP(GIVEN,EXPECTED) (strcmp(GIVEN,EXPECTED) == 0)
+
+// macros passed via test suite
+#ifndef TEST_SUITE_TARGET_NAME
+#define TEST_SUITE_TARGET_NAME "Unknown"
+#endif
+
+#ifndef TEST_SUITE_TEST_ID
+#define TEST_SUITE_TEST_ID "Unknown"
+#endif
+
+#ifndef TEST_SUITE_UUID
+#define TEST_SUITE_UUID "Unknown"
+#endif
+
+#endif

--- a/source/retarget.cpp
+++ b/source/retarget.cpp
@@ -76,7 +76,7 @@ using namespace mbed;
 #include "mbed-drivers/test_env.h"
 #endif
 
-extern bool coverage_report;
+bool coverage_report = false;
 const int gcov_fd = 'g' + ((int)'c' << 8);
 
 // Retarget specific code coverage report start notification

--- a/source/retarget.cpp
+++ b/source/retarget.cpp
@@ -69,10 +69,35 @@
 
 using namespace mbed;
 #ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
+
+#ifdef YOTTA_GREENTEA_CLIENT_VERSION_STRING
+#include "greentea-client/test_env.h"
+#else
 #include "mbed-drivers/test_env.h"
+#endif
+
 extern bool coverage_report;
 const int gcov_fd = 'g' + ((int)'c' << 8);
-#endif
+
+// Retarget specific code coverage report start notification
+static void retarget_notify_coverage_start(const char *path) {
+#ifdef YOTTA_GREENTEA_CLIENT_VERSION_STRING
+    greentea_notify_coverage_start(path);
+#else
+    notify_coverage_start(path);
+#endif  // YOTTA_GREENTEA_CLIENT_VERSION_STRING
+}
+
+// Retarget specific code coverage report end notification
+static void retarget_notify_coverage_end() {
+#ifdef YOTTA_GREENTEA_CLIENT_VERSION_STRING
+    greentea_notify_coverage_end();
+#else
+    notify_coverage_end();
+#endif  // YOTTA_GREENTEA_CLIENT_VERSION_STRING
+}
+
+#endif  // YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
 
 
 #if defined(__MICROLIB) && (__ARMCC_VERSION>5030000)
@@ -185,7 +210,7 @@ extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {
     }
 #ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
     else if(coverage_report) {
-        notify_coverage_start(name);
+        retarget_notify_coverage_start(name);
         return gcov_fd;
     }
 #endif
@@ -234,7 +259,7 @@ extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {
 extern "C" int PREFIX(_close)(FILEHANDLE fh) {
 #ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
     if(coverage_report && fh == gcov_fd) {
-        notify_coverage_end();
+        retarget_notify_coverage_end();
         return 0;
     }
 #endif
@@ -266,7 +291,14 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
 #ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
     else if(coverage_report && fh == gcov_fd) {
         for (unsigned int i = 0; i < length; i++) {
-            printf("%02x", buffer[i]);
+            if (0x00 == buffer[i]) {
+                // Very simple coverage stream compression
+                // Observation: About 30-35% of coverage stream are bytes with value 0x00
+                // Greentea will pick up '.' and replace with "00"
+                printf(".");
+            } else {
+                printf("%02x", buffer[i]);
+            }
         }
         n = length;
     }

--- a/source/test_env.cpp
+++ b/source/test_env.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2013-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mbed-drivers/test_env.h"
+
+// Const strings used in test_end
+const char* TEST_ENV_START = "start";
+const char* TEST_ENV_SUCCESS = "success";
+const char* TEST_ENV_FAILURE = "failure";
+const char* TEST_ENV_MEASURE = "measure";
+const char* TEST_ENV_END = "end";
+
+/* prototype */
+#ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
+extern "C" void __gcov_flush();
+bool coverage_report = false;
+#endif
+
+static void led_blink(PinName led, float delay)
+{
+    if (led != NC) {
+        DigitalOut myled(led);
+        while (1) {
+            myled = !myled;
+            wait(delay);
+        }
+    }
+    while(1);
+}
+
+void notify_start()
+{
+    printf("{{%s}}" NL, TEST_ENV_START);
+}
+
+void notify_performance_coefficient(const char* measurement_name, const int value)
+{
+    printf("{{%s;%s;%d}}" RCNL, TEST_ENV_MEASURE, measurement_name, value);
+}
+
+void notify_performance_coefficient(const char* measurement_name, const unsigned int value)
+{
+    printf("{{%s;%s;%u}}" RCNL, TEST_ENV_MEASURE, measurement_name, value);
+}
+
+void notify_performance_coefficient(const char* measurement_name, const double value)
+{
+    printf("{{%s;%s;%f}}" RCNL, TEST_ENV_MEASURE, measurement_name, value);
+}
+
+void notify_completion(bool success)
+{
+    printf("{{%s}}" NL, success ? TEST_ENV_SUCCESS : TEST_ENV_FAILURE);
+#ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
+    coverage_report = true;
+    __gcov_flush();
+    coverage_report = false;
+#endif
+    printf("{{%s}}" NL, TEST_ENV_END);
+    led_blink(LED1, success ? 1.0 : 0.1);
+}
+
+bool notify_completion_str(bool success, char* buffer)
+{
+    bool result = false;
+    if (buffer) {
+        sprintf(buffer, "{{%s}}" NL "{{%s}}" NL, success ? TEST_ENV_SUCCESS : TEST_ENV_FAILURE, TEST_ENV_END);
+        result = true;
+    }
+    return result;
+}
+
+// Host test auto-detection API
+void notify_host_test_name(const char *host_test) {
+    if (host_test) {
+        printf("{{host_test_name;%s}}" NL, host_test);
+    }
+}
+
+void notify_timeout(int timeout) {
+    printf("{{timeout;%d}}" NL, timeout);
+}
+
+void notify_test_id(const char *test_id) {
+    if (test_id) {
+        printf("{{test_id;%s}}" NL, test_id);
+    }
+}
+
+void notify_test_description(const char *description) {
+    if (description) {
+        printf("{{description;%s}}" NL, description);
+    }
+}
+
+#ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
+void notify_coverage_start(const char *path) {
+    printf("{{coverage_start;%s}}" NL, path);
+}
+void notify_coverage_end() {
+    printf("{{coverage_end}}" NL);
+}
+#endif
+
+// -DMBED_BUILD_TIMESTAMP=1406208182.13
+unsigned int testenv_randseed()
+{
+    unsigned int seed = 0;
+#ifdef MBED_BUILD_TIMESTAMP
+    long long_seed = static_cast<long>(MBED_BUILD_TIMESTAMP);
+    seed = long_seed & 0xFFFFFFFF;
+#endif /* MBED_BUILD_TIMESTAMP */
+    return seed;
+}

--- a/source/test_env.cpp
+++ b/source/test_env.cpp
@@ -26,7 +26,7 @@ const char* TEST_ENV_END = "end";
 /* prototype */
 #ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
 extern "C" void __gcov_flush();
-extern bool coverage_report = false;    // In retarget.cpp
+extern bool coverage_report;    // In retarget.cpp
 #endif
 
 static void led_blink(PinName led, float delay)

--- a/source/test_env.cpp
+++ b/source/test_env.cpp
@@ -26,7 +26,7 @@ const char* TEST_ENV_END = "end";
 /* prototype */
 #ifdef YOTTA_CFG_DEBUG_OPTIONS_COVERAGE
 extern "C" void __gcov_flush();
-bool coverage_report = false;
+extern bool coverage_report = false;    // In retarget.cpp
 #endif
 
 static void led_blink(PinName led, float delay)


### PR DESCRIPTION
# Changes:
* This reverts commit d8bb796. (unfortunate deletion of test_env.* files)

## Updated how we do coverage handling
* Use of ```test_env```:
  * If greentea-client dependency use greentea-client/test_env.h and greentea_*
    function from this module.
  * If no greentea-client dependency use mbed-drivers/test_env.h with old
    functionality.

## Updates to greentea-client
* See changes from PR: [[devel_transport_update] mbed-drivers with test_env alignment](https://github.com/ARMmbed/greentea-client/pull/2).
* Above changes do not brake ```utest``` v1.10.0 ```greentea-client``` ```~0.1.5``` dependencies.
* ```greentea-client``` should be released after above PR to version ```~0.1.6``` (patch version +1).

# Notes
* Users using only unity for their tests with pre Async model should stick to unity v1.9.x,