### PR TITLE
Add a target-independent instance selector

### DIFF
--- a/mbed-drivers/pinmap_common.h
+++ b/mbed-drivers/pinmap_common.h
@@ -36,6 +36,25 @@ uint32_t pinmap_merge(uint32_t a, uint32_t b);
 void     pinmap_pinout(PinName pin, const PinMap *map);
 uint32_t pinmap_find_peripheral(PinName pin, const PinMap* map);
 uint32_t pinmap_find_function(PinName pin, const PinMap* map);
+/**
+ * @brief A function for obtaining a unique index for a given peripheral
+ *
+ * This function provides a mechanism to convert an implementation-defined peripheral ID into a peripheral index. The
+ * index is obtained by order of first occurrence in the map provided. In order to prevent clashes in multi-pin
+ * peripherals, the convention is to always use the data transmit pin's map:
+ *
+ * * I2C: PinMap_I2C_SDA
+ * * Serial: PinMap_UART_TX
+ * * SPI: PinMap_SPI_MOSI
+ * * ADC: PinMap_ADC
+ * * DAC: PinMap_DAC
+ * * PWM: PinMap_PWM
+ *
+ * Note that the peripheral index is not defined to match any kind of device-defined ordering; instead, it guarantees a
+ * unique index for every logical peripheral.
+ *
+ * @param[in] peripheral The peripheral ID to search for in map
+ */
 uint32_t pinmap_peripheral_instance(uint32_t peripheral, const PinMap* map);
 
 #ifdef __cplusplus

--- a/mbed-drivers/pinmap_common.h
+++ b/mbed-drivers/pinmap_common.h
@@ -36,6 +36,7 @@ uint32_t pinmap_merge(uint32_t a, uint32_t b);
 void     pinmap_pinout(PinName pin, const PinMap *map);
 uint32_t pinmap_find_peripheral(PinName pin, const PinMap* map);
 uint32_t pinmap_find_function(PinName pin, const PinMap* map);
+uint32_t pinmap_peripheral_instance(uint32_t peripheral, const PinMap* map);
 
 #ifdef __cplusplus
 }

--- a/source/pinmap_common.c
+++ b/source/pinmap_common.c
@@ -93,8 +93,12 @@ uint32_t pinmap_peripheral_instance(uint32_t peripheral, const PinMap* map)
 {
     uint32_t idx = 0;
     for (uint32_t i = 0; map[i].pin != NC; i++) {
+        if ((uint32_t)map[i].peripheral == peripheral) {
+            // If the peripheral is a match, it must be the first occurence
+            return i ? idx + 1 : 0;
+        }
         if (i) {
-            // check that the peripheral is the first occurrence
+            // check whether this is the first occurrence of peripheral in the map
             uint32_t j;
             for (j = 0; j < i; j++) {
                 if (map[i].peripheral == map[j].peripheral) {
@@ -104,13 +108,7 @@ uint32_t pinmap_peripheral_instance(uint32_t peripheral, const PinMap* map)
             if(i == j) {
                 // this peripheral does not occur earlier in the map.
                 idx++;
-            } else {
-                // If this is not the first instance, then it can't match the input peripheral
-                continue;
             }
-        }
-        if ((uint32_t)map[i].peripheral == peripheral) {
-            return idx;
         }
     }
     return (uint32_t)NC;

--- a/source/pinmap_common.c
+++ b/source/pinmap_common.c
@@ -88,3 +88,30 @@ uint32_t pinmap_function(PinName pin, const PinMap* map) {
         error("pinmap not found for function");
     return function;
 }
+
+uint32_t pinmap_peripheral_instance(uint32_t peripheral, const PinMap* map)
+{
+    uint32_t idx = 0;
+    for (uint32_t i = 0; map[i].pin != NC; i++) {
+        if (i) {
+            // check that the peripheral is the first occurrence
+            uint32_t j;
+            for (j = 0; j < i; j++) {
+                if (map[i].peripheral == map[j].peripheral) {
+                    break;
+                }
+            }
+            if(i == j) {
+                // this peripheral does not occur earlier in the map.
+                idx++;
+            } else {
+                // If this is not the first instance, then it can't match the input peripheral
+                continue;
+            }
+        }
+        if ((uint32_t)map[i].peripheral == peripheral) {
+            return idx;
+        }
+    }
+    return (uint32_t)NC;
+}

--- a/source/v2/I2C.cpp
+++ b/source/v2/I2C.cpp
@@ -129,7 +129,14 @@ I2C::I2C(PinName sda, PinName scl) :
     // Select the appropriate I2C Resource Manager
     uint32_t i2c_sda = pinmap_peripheral(sda, PinMap_I2C_SDA);
     uint32_t i2c_scl = pinmap_peripheral(scl, PinMap_I2C_SCL);
-    int ownerID = pinmap_merge(i2c_sda, i2c_scl);
+    uint32_t peripheral = pinmap_merge(i2c_sda, i2c_scl);
+    CORE_UTIL_ASSERT(peripheral != (uint32_t)NC);
+    if (peripheral == (uint32_t)NC) {
+        _owner = NULL;
+        return;
+    }
+    uint32_t ownerID = pinmap_peripheral_instance(peripheral, PinMap_I2C_SDA);
+    CORE_UTIL_ASSERT(ownerID != (uint32_t)NC);
     _owner = detail::get_i2c_owner(ownerID);
     if (I2CError::None != _owner->init(sda, scl)) {
         error("I2C init failed with an error");


### PR DESCRIPTION
Selects the instance by finding unique peripheral IDs in the pinmap.

Fixes #166 

cc @0xc0170 @marcuschangarm @bogdanm 