### PR TITLE
Add warning regarding deprecated mbed-drivers/test_env.h

### DIFF
--- a/mbed-drivers/test_env.h
+++ b/mbed-drivers/test_env.h
@@ -16,6 +16,7 @@
  */
 #ifndef TEST_ENV_H_
 #define TEST_ENV_H_
+#warning mbed-drivers/test_env.h is deprecated. Please use greentea-client/test_env.h instead.
 
 #include <stdio.h>
 #include "mbed.h"


### PR DESCRIPTION
Changes:
* This is a response for comments from code review of https://github.com/ARMmbed/mbed-drivers/pull/165.