### PR TITLE
Dependency testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: cpp
+python:
+  - "2.7"
+install:
+  # Install ARM GCC
+  - sudo apt-get remove binutils-arm-none-eabi gcc-arm-none-eabi
+  - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
+  - sudo apt-get update
+  - sudo apt-get install gcc-arm-embedded
+  # Install yotta
+  - pip install --user yotta
+script:
+  # Build all tests for frdm-k64f-gcc
+  - yotta target frdm-k64f-gcc
+  - yotta build all_tests
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - george-edison55-precise-backports
+      - ubuntu-toolchain-r-test
+    packages:
+      - cmake
+      - cmake-data
+      - g++-4.8
+      - python-setuptools
+      - cmake
+      - build-essential
+      - ninja-build
+      - python-dev
+      - libffi-dev
+      - libssl-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ python:
   - "2.7"
 install:
   # Install ARM GCC
-  - sudo apt-get remove binutils-arm-none-eabi gcc-arm-none-eabi
-  - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
+  - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
   - sudo apt-get update
-  - sudo apt-get install gcc-arm-embedded
+  - sudo apt-get install gcc-arm-embedded -y
   # Install yotta
   - pip install --user yotta
 script:
   # Build all tests for frdm-k64f-gcc
   - yotta target frdm-k64f-gcc
+  - yotta install
   - yotta build all_tests
 env:
   - CXX=g++-4.8


### PR DESCRIPTION
This is in response to the discussion on #172.

This builds all tests for mbed drivers whenever a PR or commit on master is submitted. This should hopefully catch any existing issues between all the dependencies.
