### PR TITLE
Fix warnings in mbed_debug.h

### DIFF
--- a/mbed-drivers/mbed_debug.h
+++ b/mbed-drivers/mbed_debug.h
@@ -55,8 +55,13 @@ static inline void debug_if(int condition, const char *format, ...) {
 }
 
 #else
-static inline void debug(const char *format, ...) {}
-static inline void debug_if(int condition, const char *format, ...) {}
+static inline void debug(const char *format, ...) {
+    (void)format;
+}
+static inline void debug_if(int condition, const char *format, ...) {
+    (void)condition;
+    (void)format;
+}
 
 #endif
 


### PR DESCRIPTION
Without this mbed always generates warnings for these unused parameters.